### PR TITLE
feat: Implement backend microservices and API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,78 @@
-# JBio Hub Sample - Jeonbuk Bio Web Platform
+# JBio Hub - Backend Monorepo
 
-This project is a sample implementation of a web platform for the Jeonbuk Bio industry, named "JBio Hub". It showcases a modern, clean dashboard interface built with React. This project was created to demonstrate a high-quality, production-level frontend structure, including a design system and component-based architecture, all within a single file for simplicity.
+This repository contains the backend microservices for the JBio Hub platform. It is structured as a monorepo using npm workspaces, and it lives alongside the React frontend application.
 
-![JBio Hub Screenshot](public/screenshot.png)
+## Project Structure
 
-*(Note: The screenshot is a placeholder. You can generate one by running the application and taking a screenshot of the main page.)*
-
-## About The Project
-
-JBio Hub is envisioned as a central platform for the Jeonbuk bio-industry ecosystem. It provides a comprehensive dashboard for users to access information about announcements, business incubation centers, company information, technology trends, and news.
-
-The interface is designed to be intuitive and user-friendly, with a focus on data visualization and quick access to key services.
-
-### Key Features
-
-*   **Modern Dashboard UI:** A clean and professional user interface.
-*   **Design System:** A built-in design system for colors, typography, spacing, and shadows.
-*   **SVG Icon Library:** A set of custom, high-quality SVG icons for UI elements.
-*   **Responsive Header:** Includes navigation and user profile sections.
-*   **Hero Section:** A prominent search bar for easy access to information.
-*   **Statistics Overview:** Key metrics are displayed in an easy-to-digest format.
-*   **Main Services Section:** Highlights the core services of the platform.
-*   **Content Grids:** Sections for the latest announcements and news.
-*   **Professional Footer:** Comprehensive footer with contact information, site links, and legal notices.
-
-## Built With
-
-*   [React](https://reactjs.org/)
-*   [React Router](https://reactrouter.com/)
-*   [React Scripts](https://create-react-app.dev/)
-*   [GitHub Pages](https://pages.github.com/)
+-   `package.json`: The root package file, configured for npm workspaces. Manages all services and shared dependencies.
+-   `src/`, `public/`: The React frontend application.
+-   `packages/`: Contains shared code used by multiple services.
+    -   `common/`: A placeholder for common utilities.
+-   `services/`: Contains all the individual microservices.
+    -   `gateway-service/`: The single entry point (API Gateway) for the frontend.
+    -   `announcement-service/`: Manages announcements.
+    -   `company-service/`: Manages company and institution data.
+    -   `infra-service/`: Manages infrastructure data for the map.
+    -   `content-service/`: Manages news, notices, and tech achievements.
+    -   `consultation-service/`: Manages consultation requests.
+    -   `user-service/`: Manages user authentication and data.
+    -   `admin-service/`: Manages administrative tasks.
 
 ## Getting Started
 
-To get a local copy up and running, follow these simple steps.
-
 ### Prerequisites
 
-You need to have Node.js and npm installed on your machine.
-*   npm
-    ```sh
-    npm install npm@latest -g
-    ```
+-   Node.js (v16 or higher)
+-   npm (v7 or higher, for workspace support)
 
 ### Installation
 
-1.  Clone the repo
-    ```sh
-    git clone https://github.com/your_username/jbio-hub-sample.git
-    ```
-2.  Install NPM packages
-    ```sh
+1.  Clone the repository.
+2.  Install all dependencies for the frontend and all backend services from the root directory:
+    ```bash
     npm install
     ```
 
-## Usage
+### Running the Services
 
-To run the app in development mode, use the following command. This will open the app in your default browser at `http://localhost:3000`.
+#### Run All Backend Services
 
-```sh
+To run all backend microservices and the API gateway concurrently, use the following command from the root directory:
+
+```bash
+npm run dev
+```
+
+This will start all services on their respective ports. The API Gateway will be available at `http://localhost:3000`.
+
+#### Run a Single Service
+
+To run a specific microservice for development, you can use the npm workspace command. For example, to run only the `announcement-service`:
+
+```bash
+npm run dev -w @gonggo/announcement-service
+```
+
+#### Run the Frontend
+
+To run the React frontend application, use the standard start script:
+
+```bash
 npm start
 ```
 
-## Available Scripts
+This will start the React development server, usually on `http://localhost:3001` (or the next available port if 3000 is taken by the gateway).
 
-In the project directory, you can run:
+## API Endpoints
 
-### `npm start`
+All backend APIs are accessed through the API Gateway at `http://localhost:3000/api`.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-### `npm run deploy`
-
-This command builds the application and deploys it to GitHub Pages.
-
-## License
-
-Distributed under the MIT License.
+-   **Announcements**: `GET /api/announcements`, `GET /api/announcements/:id`
+-   **Companies**: `GET /api/companies`, `GET /api/companies/:id`
+-   **Infrastructure**: `GET /api/infra/map`
+-   **Content**:
+    -   `GET /api/news`, `GET /api/news/:id`
+    -   `GET /api/techs`, `GET /api/techs/:id`
+-   **Consultations**: `POST /api/consultations`
+-   **Users**: `POST /api/auth/login`, `GET /api/me` (requires Bearer token)
+-   **Admin**: `GET, POST, PUT, DELETE /api/admin/*` (requires `X-User-Role: admin` header)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
-  "name": "jbio-hub-sample",
+  "name": "jbio-hub-monorepo",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jbio-hub-sample",
+      "name": "jbio-hub-monorepo",
       "version": "1.0.0",
       "license": "MIT",
+      "workspaces": [
+        "services/*",
+        "packages/*"
+      ],
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -21,6 +25,7 @@
         "@types/react-dom": "^18.3.7",
         "@types/react-router-dom": "^5.3.3",
         "gh-pages": "^5.0.0",
+        "npm-run-all": "^4.1.5",
         "typescript": "~4.9.5"
       }
     },
@@ -2455,6 +2460,38 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@gonggo/admin-service": {
+      "resolved": "services/admin-service",
+      "link": true
+    },
+    "node_modules/@gonggo/announcement-service": {
+      "resolved": "services/announcement-service",
+      "link": true
+    },
+    "node_modules/@gonggo/company-service": {
+      "resolved": "services/company-service",
+      "link": true
+    },
+    "node_modules/@gonggo/consultation-service": {
+      "resolved": "services/consultation-service",
+      "link": true
+    },
+    "node_modules/@gonggo/content-service": {
+      "resolved": "services/content-service",
+      "link": true
+    },
+    "node_modules/@gonggo/gateway-service": {
+      "resolved": "services/gateway-service",
+      "link": true
+    },
+    "node_modules/@gonggo/infra-service": {
+      "resolved": "services/infra-service",
+      "link": true
+    },
+    "node_modules/@gonggo/user-service": {
+      "resolved": "services/user-service",
+      "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -9209,6 +9246,13 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -11281,6 +11325,13 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11477,6 +11528,56 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -11654,6 +11755,15 @@
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -11887,6 +11997,13 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -11918,6 +12035,29 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11946,6 +12086,183 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/npm-run-path": {
@@ -12437,6 +12754,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -14401,6 +14731,44 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -15475,6 +15843,42 @@
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "license": "MIT"
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -15769,6 +16173,25 @@
         "regexp.prototype.flags": "^1.5.3",
         "set-function-name": "^2.0.2",
         "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17012,6 +17435,17 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -17953,6 +18387,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/admin-service": {
+      "name": "@gonggo/admin-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/announcement-service": {
+      "name": "@gonggo/announcement-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/company-service": {
+      "name": "@gonggo/company-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/consultation-service": {
+      "name": "@gonggo/consultation-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/content-service": {
+      "name": "@gonggo/content-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/gateway-service": {
+      "name": "@gonggo/gateway-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "http-proxy-middleware": "^2.0.6"
+      }
+    },
+    "services/infra-service": {
+      "name": "@gonggo/infra-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "services/user-service": {
+      "name": "@gonggo/user-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,35 @@
 {
-  "name": "jbio-hub-sample",
+  "name": "jbio-hub-monorepo",
   "version": "1.0.0",
-  "description": "Jeonbuk Bio Web Platform - Molecular Research Hub",
-  "main": "src/App.js",
-  "homepage": "https://viakisun.github.io/jbio-hub-sample",
+  "private": true,
+  "description": "Jeonbuk Bio Web Platform - Monorepo for Frontend and Backend",
+  "workspaces": [
+    "services/*",
+    "packages/*"
+  ],
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "npm run build && gh-pages -d build"
+    "deploy": "npm run build && gh-pages -d build",
+    "dev": "npm-run-all --parallel dev:*",
+    "dev:announcements": "npm run dev -w @gonggo/announcement-service",
+    "dev:companies": "npm run dev -w @gonggo/company-service",
+    "dev:infra": "npm run dev -w @gonggo/infra-service",
+    "dev:content": "npm run dev -w @gonggo/content-service",
+    "dev:consultation": "npm run dev -w @gonggo/consultation-service",
+    "dev:user": "npm run dev -w @gonggo/user-service",
+    "dev:admin": "npm run dev -w @gonggo/admin-service",
+    "dev:gateway": "npm run dev -w @gonggo/gateway-service"
   },
   "keywords": [
     "biotechnology",
     "molecules",
     "research",
     "jeonbuk",
-    "atomic-design"
+    "atomic-design",
+    "monorepo"
   ],
   "author": "Jeonbuk Bio Team",
   "license": "MIT",
@@ -33,6 +46,7 @@
     "@types/react-dom": "^18.3.7",
     "@types/react-router-dom": "^5.3.3",
     "gh-pages": "^5.0.0",
+    "npm-run-all": "^4.1.5",
     "typescript": "~4.9.5"
   },
   "browserslist": {

--- a/services/admin-service/index.js
+++ b/services/admin-service/index.js
@@ -1,0 +1,158 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+// NOTE: This is NOT a typical microservice pattern.
+// In a real-world scenario, this service would communicate with other services via their APIs or a shared message bus.
+// For this simulation, we are directly accessing the mock data files as requested.
+const { announcements } = require('../announcement-service/db/mock-data');
+const { companies } = require('../company-service/db/mock-data');
+
+const app = express();
+const port = 3099; // Admin service port
+
+app.use(express.json());
+
+// --- Middleware for mock auth ---
+// A simple check for an admin role.
+const isAdmin = (req, res, next) => {
+  // In a real app, this would check a JWT token.
+  if (req.headers['x-user-role'] === 'admin') {
+    next();
+  } else {
+    res.status(403).json({ error: 'Forbidden: Admin access required' });
+  }
+};
+
+// All admin routes are protected
+app.use(isAdmin);
+
+// --- Dashboard ---
+// UI-99-01: 관리자 대시보드
+app.get('/dashboard', (req, res) => {
+  res.json({
+    summary: {
+      announcements: announcements.length,
+      companies: companies.length,
+      // ... other counts
+    },
+    message: 'Admin dashboard data'
+  });
+});
+
+// --- Announcement Management ---
+// UI-99-02: 공고 관리
+
+// Get all announcements
+app.get('/announcements', (req, res) => {
+  res.json(announcements);
+});
+
+// Create a new announcement
+app.post('/announcements', (req, res) => {
+  const { title, content, author } = req.body;
+  if (!title || !content) {
+    return res.status(400).json({ error: 'Title and content are required' });
+  }
+  const newAnnouncement = {
+    id: announcements.length > 0 ? Math.max(...announcements.map(a => a.id)) + 1 : 1,
+    title,
+    content,
+    author: author || 'Administrator',
+    createdAt: new Date().toISOString(),
+    files: [],
+    relatedLinks: []
+  };
+  announcements.push(newAnnouncement);
+  // Note: This only modifies the in-memory array. It does not write back to the file.
+  res.status(201).json(newAnnouncement);
+});
+
+// Update an announcement
+app.put('/announcements/:id', (req, res) => {
+  const { id } = req.params;
+  const { title, content, author } = req.body;
+  const announcementIndex = announcements.findIndex(a => a.id === parseInt(id));
+
+  if (announcementIndex === -1) {
+    return res.status(404).json({ error: 'Announcement not found' });
+  }
+
+  const updatedAnnouncement = { ...announcements[announcementIndex], title, content, author, updatedAt: new Date().toISOString() };
+  announcements[announcementIndex] = updatedAnnouncement;
+
+  res.json(updatedAnnouncement);
+});
+
+// Delete an announcement
+app.delete('/announcements/:id', (req, res) => {
+  const { id } = req.params;
+  const announcementIndex = announcements.findIndex(a => a.id === parseInt(id));
+
+  if (announcementIndex === -1) {
+    return res.status(404).json({ error: 'Announcement not found' });
+  }
+
+  announcements.splice(announcementIndex, 1);
+  res.status(204).send(); // No Content
+});
+
+
+// --- Company/Institution Management ---
+// UI-99-03: 기관/기업 관리
+
+app.get('/companies', (req, res) => {
+  res.json(companies);
+});
+
+app.post('/companies', (req, res) => {
+  const { name, type, description } = req.body;
+  if (!name || !type) {
+    return res.status(400).json({ error: 'Name and type are required' });
+  }
+  const newCompany = {
+    id: companies.length > 0 ? Math.max(...companies.map(c => c.id)) + 1 : 1,
+    name,
+    type,
+    description: description || '',
+    createdAt: new Date().toISOString()
+  };
+  companies.push(newCompany);
+  res.status(201).json(newCompany);
+});
+
+app.put('/companies/:id', (req, res) => {
+  const { id } = req.params;
+  const { name, type, description } = req.body;
+  const companyIndex = companies.findIndex(c => c.id === parseInt(id));
+
+  if (companyIndex === -1) {
+    return res.status(404).json({ error: 'Company not found' });
+  }
+
+  const updatedCompany = { ...companies[companyIndex], name, type, description, updatedAt: new Date().toISOString() };
+  companies[companyIndex] = updatedCompany;
+
+  res.json(updatedCompany);
+});
+
+app.delete('/companies/:id', (req, res) => {
+  const { id } = req.params;
+  const companyIndex = companies.findIndex(c => c.id === parseInt(id));
+
+  if (companyIndex === -1) {
+    return res.status(404).json({ error: 'Company not found' });
+  }
+
+  companies.splice(companyIndex, 1);
+  res.status(204).send();
+});
+
+
+app.get('/', (req, res) => {
+  res.send('Admin service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Admin service listening at http://localhost:${port}`);
+});

--- a/services/admin-service/package.json
+++ b/services/admin-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/admin-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/announcement-service/db/mock-data.js
+++ b/services/announcement-service/db/mock-data.js
@@ -1,0 +1,67 @@
+/*
+-- Database Schema for Announcements
+-- This file contains mock data for development purposes.
+-- In a real production environment, you would use a proper database.
+
+-- Table: announcements
+CREATE TABLE announcements (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    author VARCHAR(100),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CRUD Operations Examples
+
+-- CREATE (INSERT)
+INSERT INTO announcements (title, content, author) VALUES ('바이오 데이터 분석 전문가 채용', '상세 내용은 첨부파일 확인', '국립보건연구원');
+
+-- READ (SELECT)
+-- 모든 공고 조회
+SELECT * FROM announcements ORDER BY created_at DESC;
+-- 특정 공고 조회
+SELECT * FROM announcements WHERE id = 1;
+
+-- UPDATE
+UPDATE announcements SET title = '수정된 제목', content = '수정된 내용' WHERE id = 1;
+
+-- DELETE
+DELETE FROM announcements WHERE id = 1;
+
+*/
+
+const announcements = [
+  {
+    id: 1,
+    title: '2025년 상반기 바이오 연구직 채용 공고',
+    content: '유전체 분석 및 단백질체학 연구 분야의 신규 연구원을 모집합니다. 상세 요강은 홈페이지를 참고하세요.',
+    author: '전북바이오융합산업진흥원',
+    createdAt: '2025-08-10T10:00:00Z',
+    files: [{ name: '채용공고.pdf', url: '/files/recruitment_notice_01.pdf' }],
+    relatedLinks: [{ title: '진흥원 홈페이지', url: 'https://www.jif.re.kr/' }]
+  },
+  {
+    id: 2,
+    title: '미생물 배양 기술 이전 설명회 개최',
+    content: '신규 미생물 배양 기술에 대한 기술 이전 설명회를 개최합니다. 관심 있는 기업 및 기관의 많은 참여 바랍니다.',
+    author: '한국생명공학연구원',
+    createdAt: '2025-08-05T14:30:00Z',
+    files: [{ name: '기술이전설명회_안내.hwp', url: '/files/tech_briefing_01.hwp' }],
+    relatedLinks: []
+  },
+  {
+    id: 3,
+    title: '제3회 바이오산업 포럼 참가 신청',
+    content: '미래 바이오산업의 전망을 주제로 제3회 바이오산업 포럼이 개최됩니다. 참가 신청은 8월 20일까지입니다.',
+    author: '산업통상자원부',
+    createdAt: '2025-07-28T09:00:00Z',
+    files: [],
+    relatedLinks: [{ title: '포럼 신청 페이지', url: 'https://example.com/forum-signup' }]
+  }
+];
+
+module.exports = {
+  announcements
+};

--- a/services/announcement-service/index.js
+++ b/services/announcement-service/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const { announcements } = require('./db/mock-data');
+
+const app = express();
+const port = 3001;
+
+app.use(express.json());
+
+// --- API Endpoints ---
+
+// UI-01-02: 공고 목록 (Get list of announcements)
+app.get('/announcements', (req, res) => {
+  // In a real app, you might add filtering and pagination here
+  // e.g., /announcements?sort=newest&page=1
+  res.json(announcements);
+});
+
+// UI-01-03: 공고 상세 (Get a single announcement by ID)
+app.get('/announcements/:id', (req, res) => {
+  const { id } = req.params;
+  const announcement = announcements.find(a => a.id === parseInt(id));
+
+  if (announcement) {
+    res.json(announcement);
+  } else {
+    res.status(404).json({ error: 'Announcement not found' });
+  }
+});
+
+app.get('/', (req, res) => {
+  res.send('Announcement service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Announcement service listening at http://localhost:${port}`);
+});

--- a/services/announcement-service/package.json
+++ b/services/announcement-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/announcement-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/company-service/db/mock-data.js
+++ b/services/company-service/db/mock-data.js
@@ -1,0 +1,71 @@
+/*
+-- Database Schema for Companies/Institutions
+
+-- Table: companies
+CREATE TABLE companies (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL, -- '기업' or '기관'
+    description TEXT,
+    address VARCHAR(255),
+    contact_person VARCHAR(100),
+    contact_email VARCHAR(100),
+    contact_phone VARCHAR(50),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CRUD Operations Examples
+
+-- CREATE (INSERT)
+INSERT INTO companies (name, type, description, address, contact_person, contact_email, contact_phone)
+VALUES ('(주)바이오노트', '기업', '동물용 진단제품 개발 및 제조', '전라북도 익산시', '김담당', 'contact@bionote.co.kr', '063-123-4567');
+
+-- READ (SELECT)
+SELECT * FROM companies WHERE type = '기업';
+SELECT * FROM companies WHERE id = 1;
+
+-- UPDATE
+UPDATE companies SET contact_person = '박담당' WHERE id = 1;
+
+-- DELETE
+DELETE FROM companies WHERE id = 1;
+
+*/
+
+const companies = [
+  {
+    id: 1,
+    name: '(주)바이오노트',
+    type: '기업',
+    description: '동물용 진단제품 개발 및 제조를 선도하는 기업입니다.',
+    address: '전라북도 익산시 왕궁면 국가식품로 100',
+    contactPerson: '김담당',
+    contactEmail: 'contact@bionote.co.kr',
+    contactPhone: '063-123-4567'
+  },
+  {
+    id: 2,
+    name: '한국생명공학연구원 전북분원',
+    type: '기관',
+    description: '생명공학 분야의 국가 거점 연구기관입니다.',
+    address: '전라북도 정읍시 입암면 첨단과기로 241',
+    contactPerson: '이연구원',
+    contactEmail: 'info@kribb.re.kr',
+    contactPhone: '063-570-5600'
+  },
+  {
+    id: 3,
+    name: '전북대학교 병원',
+    type: '기관',
+    description: '지역 거점 국립대학교 병원. 임상 연구 및 시험 진행.',
+    address: '전라북도 전주시 덕진구 건지로 20',
+    contactPerson: '최교수',
+    contactEmail: 'med@jbnu.ac.kr',
+    contactPhone: '063-250-1114'
+  }
+];
+
+module.exports = {
+  companies
+};

--- a/services/company-service/index.js
+++ b/services/company-service/index.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const { companies } = require('./db/mock-data');
+
+const app = express();
+const port = 3002;
+
+app.use(express.json());
+
+// --- API Endpoints ---
+
+// UI-02-01: 기업/기관 목록 (Get list of companies/institutions)
+app.get('/companies', (req, res) => {
+  // In a real app, you could filter by type, e.g., /companies?type=기업
+  const { type } = req.query;
+  if (type) {
+    const filteredCompanies = companies.filter(c => c.type === type);
+    return res.json(filteredCompanies);
+  }
+  res.json(companies);
+});
+
+// UI-02-02: 기업/기관 상세 (Get a single company/institution by ID)
+app.get('/companies/:id', (req, res) => {
+  const { id } = req.params;
+  const company = companies.find(c => c.id === parseInt(id));
+
+  if (company) {
+    res.json(company);
+  } else {
+    res.status(404).json({ error: 'Company or institution not found' });
+  }
+});
+
+app.get('/', (req, res) => {
+  res.send('Company/Institution service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Company/Institution service listening at http://localhost:${port}`);
+});

--- a/services/company-service/package.json
+++ b/services/company-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/company-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/consultation-service/db/mock-data.js
+++ b/services/consultation-service/db/mock-data.js
@@ -1,0 +1,36 @@
+/*
+-- Database Schema for Consultations
+
+-- Table: consultations
+CREATE TABLE consultations (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    phone VARCHAR(50),
+    organization VARCHAR(100),
+    subject VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    status VARCHAR(50) DEFAULT 'submitted', -- 'submitted', 'in_progress', 'completed'
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CRUD Operations Examples
+
+-- CREATE (INSERT)
+INSERT INTO consultations (name, email, subject, body)
+VALUES ('홍길동', 'gildong@example.com', '기술이전 문의', 'A기술에 대한 상세 자료를 받고 싶습니다.');
+
+-- READ (SELECT)
+SELECT * FROM consultations WHERE status = 'submitted';
+
+-- UPDATE
+UPDATE consultations SET status = 'in_progress' WHERE id = 1;
+
+*/
+
+// In-memory store for consultation requests
+const consultations = [];
+
+module.exports = {
+  consultations
+};

--- a/services/consultation-service/index.js
+++ b/services/consultation-service/index.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const { consultations } = require('./db/mock-data');
+
+const app = express();
+const port = 3005;
+
+app.use(express.json());
+
+// --- API Endpoints ---
+
+// UI-06-01: 상담 신청 (Submit a consultation request)
+app.post('/consultations', (req, res) => {
+  const { name, email, phone, organization, subject, body } = req.body;
+
+  if (!name || !email || !subject || !body) {
+    return res.status(400).json({ error: 'Missing required fields: name, email, subject, body' });
+  }
+
+  const newConsultation = {
+    id: consultations.length + 1, // simple id generation
+    name,
+    email,
+    phone,
+    organization,
+    subject,
+    body,
+    status: 'submitted',
+    createdAt: new Date().toISOString()
+  };
+
+  consultations.push(newConsultation);
+
+  console.log('New consultation submitted:', newConsultation);
+  res.status(201).json(newConsultation);
+});
+
+// Helper endpoint to view submitted consultations
+app.get('/consultations', (req, res) => {
+  res.json(consultations);
+});
+
+app.get('/', (req, res) => {
+  res.send('Consultation service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Consultation service listening at http://localhost:${port}`);
+});

--- a/services/consultation-service/package.json
+++ b/services/consultation-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/consultation-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/content-service/db/mock-data.js
+++ b/services/content-service/db/mock-data.js
@@ -1,0 +1,64 @@
+/*
+-- Database Schema for Content (News and Tech)
+
+-- Table: news
+CREATE TABLE news (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    category VARCHAR(50) DEFAULT 'news', -- 'news', 'notice'
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table: techs
+CREATE TABLE techs (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    field VARCHAR(100), -- '바이오', '농생명', '의료'
+    description TEXT,
+    presenter VARCHAR(100), -- 발표자/연구자
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+*/
+
+const news = [
+  {
+    id: 1,
+    title: '전북 바이오 특화단지 유치 성공',
+    content: '정부가 전북을 바이오 특화단지로 최종 선정했습니다. 이로써 지역 내 바이오 산업의 성장이 기대됩니다.',
+    category: 'news',
+    createdAt: '2025-08-12T11:00:00Z'
+  },
+  {
+    id: 2,
+    title: '시스템 점검 안내 (09/01 02:00 ~ 04:00)',
+    content: '더 나은 서비스 제공을 위해 시스템 정기 점검을 실시합니다. 점검 시간에는 서비스 이용이 일시 중단될 수 있습니다.',
+    category: 'notice',
+    createdAt: '2025-08-11T17:00:00Z'
+  }
+];
+
+const techs = [
+  {
+    id: 1,
+    title: '유전자 가위 기술을 이용한 신품종 개발',
+    field: '농생명',
+    description: 'CRISPR-Cas9 기술을 활용하여 특정 유전자를 편집, 병충해에 강한 신품종 쌀을 개발하는 데 성공했습니다.',
+    presenter: '한국농업기술원',
+    createdAt: '2025-08-01T15:00:00Z'
+  },
+  {
+    id: 2,
+    title: '미생물 기반 암 치료제 개발 성과',
+    field: '의료',
+    description: '장내 미생물을 활용한 면역 항암 치료제의 초기 임상 시험에서 긍정적인 결과를 얻었습니다.',
+    presenter: '(주)마이크로바이옴',
+    createdAt: '2025-07-20T10:30:00Z'
+  }
+];
+
+module.exports = {
+  news,
+  techs
+};

--- a/services/content-service/index.js
+++ b/services/content-service/index.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { news, techs } = require('./db/mock-data');
+
+const app = express();
+const port = 3004;
+
+app.use(express.json());
+
+// --- News API Endpoints ---
+
+// UI-04-01: 뉴스/공지 목록
+app.get('/news', (req, res) => {
+  res.json(news);
+});
+
+// UI-04-02: 뉴스/공지 상세
+app.get('/news/:id', (req, res) => {
+  const { id } = req.params;
+  const item = news.find(n => n.id === parseInt(id));
+  if (item) {
+    res.json(item);
+  } else {
+    res.status(404).json({ error: 'News or notice not found' });
+  }
+});
+
+
+// --- Tech/Achievements API Endpoints ---
+
+// UI-05-01: 기술/성과 목록
+app.get('/techs', (req, res) => {
+  res.json(techs);
+});
+
+// UI-05-02: 기술/성과 상세
+app.get('/techs/:id', (req, res) => {
+  const { id } = req.params;
+  const item = techs.find(t => t.id === parseInt(id));
+  if (item) {
+    res.json(item);
+  } else {
+    res.status(404).json({ error: 'Technology or achievement not found' });
+  }
+});
+
+
+app.get('/', (req, res) => {
+  res.send('Content service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Content service listening at http://localhost:${port}`);
+});

--- a/services/content-service/package.json
+++ b/services/content-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/content-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/gateway-service/index.js
+++ b/services/gateway-service/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+const port = 3000;
+
+const services = [
+  { route: '/api/announcements', target: 'http://localhost:3001' },
+  { route: '/api/companies', target: 'http://localhost:3002' },
+  { route: '/api/infra', target: 'http://localhost:3003' },
+  { route: '/api/news', target: 'http://localhost:3004' },
+  { route: 'api/techs', target: 'http://localhost:3004' },
+  { route: '/api/consultations', target: 'http://localhost:3005' },
+  { route: '/api/auth', target: 'http://localhost:3006' },
+  { route: '/api/me', target: 'http://localhost:3006' },
+  { route: '/api/admin', target: 'http://localhost:3099' }
+];
+
+services.forEach(({ route, target }) => {
+  app.use(route, createProxyMiddleware({
+    target,
+    changeOrigin: true,
+    pathRewrite: (path, req) => {
+      // Rewrite /api/announcements to /announcements
+      return path.replace('/api', '');
+    }
+  }));
+});
+
+app.get('/', (req, res) => {
+  res.send('API Gateway is running!');
+});
+
+app.listen(port, () => {
+  console.log(`API Gateway listening at http://localhost:${port}`);
+});

--- a/services/gateway-service/package.json
+++ b/services/gateway-service/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@gonggo/gateway-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6"
+  }
+}

--- a/services/infra-service/db/mock-data.js
+++ b/services/infra-service/db/mock-data.js
@@ -1,0 +1,74 @@
+/*
+-- Database Schema for Infrastructure
+
+-- Table: infrastructure
+CREATE TABLE infrastructure (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    category VARCHAR(100), -- e.g., '연구시설', '편의시설'
+    address VARCHAR(255),
+    latitude DECIMAL(9, 6) NOT NULL,
+    longitude DECIMAL(9, 6) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CRUD Operations Examples
+
+-- CREATE (INSERT)
+INSERT INTO infrastructure (name, category, address, latitude, longitude, description)
+VALUES ('전북바이오융합산업진흥원', '연구시설', '전주시 덕진구', 35.847421, 127.129223, '바이오 산업의 핵심 연구 기관');
+
+-- READ (SELECT)
+SELECT * FROM infrastructure;
+
+-- UPDATE
+UPDATE infrastructure SET name = 'JIF' WHERE id = 1;
+
+-- DELETE
+DELETE FROM infrastructure WHERE id = 1;
+
+*/
+
+const infrastructure = [
+  {
+    id: 1,
+    name: '전북바이오융합산업진흥원',
+    category: '연구시설',
+    address: '전라북도 전주시 덕진구 월드컵로 305',
+    latitude: 35.8613,
+    longitude: 127.0648,
+    description: '바이오 산업의 핵심 연구 및 지원 기관.'
+  },
+  {
+    id: 2,
+    name: '한국생명공학연구원 전북분원',
+    category: '연구시설',
+    address: '전라북도 정읍시 입암면 첨단과기로 241',
+    latitude: 35.5931,
+    longitude: 126.8665,
+    description: '국가 생명공학 연구의 중심.'
+  },
+  {
+    id: 3,
+    name: '농축산용 미생물산업육성지원센터',
+    category: '지원시설',
+    address: '전라북도 정읍시 신정동 1558-2',
+    latitude: 35.5675,
+    longitude: 126.8820,
+    description: '농축산용 미생물 관련 기업 지원 및 육성.'
+  },
+  {
+    id: 4,
+    name: '안전성평가연구소 전북분소',
+    category: '연구시설',
+    address: '전라북도 정읍시 입암면 첨단과기로 190',
+    latitude: 35.5900,
+    longitude: 126.8632,
+    description: '화학·바이오 물질의 안전성 평가 전문 연구기관.'
+  }
+];
+
+module.exports = {
+  infrastructure
+};

--- a/services/infra-service/index.js
+++ b/services/infra-service/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { infrastructure } = require('./db/mock-data');
+
+const app = express();
+const port = 3003;
+
+app.use(express.json());
+
+// --- API Endpoints ---
+
+// UI-03-01: 클러스터 지도 (Get all infrastructure points for the map)
+app.get('/infra/map', (req, res) => {
+  res.json(infrastructure);
+});
+
+app.get('/', (req, res) => {
+  res.send('Infrastructure service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`Infrastructure service listening at http://localhost:${port}`);
+});

--- a/services/infra-service/package.json
+++ b/services/infra-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/infra-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/user-service/db/mock-data.js
+++ b/services/user-service/db/mock-data.js
@@ -1,0 +1,42 @@
+/*
+-- Database Schema for Users
+
+-- Table: users
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL, -- Never store plain text passwords!
+    email VARCHAR(100) UNIQUE NOT NULL,
+    full_name VARCHAR(100),
+    role VARCHAR(50) DEFAULT 'user', -- 'user', 'admin'
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+*/
+
+const users = [
+  {
+    id: 1,
+    username: 'testuser',
+    password: 'password123', // In a real app, this would be a hash
+    email: 'testuser@example.com',
+    fullName: '테스트 사용자',
+    role: 'user',
+    interests: ['바이오', '의료'],
+    consultationHistory: [1]
+  },
+  {
+    id: 2,
+    username: 'admin',
+    password: 'adminpassword',
+    email: 'admin@example.com',
+    fullName: '관리자',
+    role: 'admin',
+    interests: [],
+    consultationHistory: []
+  }
+];
+
+module.exports = {
+  users
+};

--- a/services/user-service/index.js
+++ b/services/user-service/index.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const { users } = require('./db/mock-data');
+
+const app = express();
+const port = 3006;
+
+app.use(express.json());
+
+// --- API Endpoints ---
+
+// UI-07-01: 로그인 (Login)
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+
+  if (user) {
+    // In a real app, generate a real JWT token.
+    const mockToken = `fake-jwt-token-for-user-${user.id}`;
+    res.json({
+      message: 'Login successful',
+      token: mockToken,
+      user: { id: user.id, username: user.username, fullName: user.fullName, role: user.role }
+    });
+  } else {
+    res.status(401).json({ error: 'Invalid username or password' });
+  }
+});
+
+// UI-07-02: 마이페이지 (My Page)
+// This is a mock protected route.
+app.get('/me', (req, res) => {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized: No token provided' });
+  }
+
+  // In a real app, you would verify the token.
+  // Here, we'll just pretend to and return the first user's data.
+  const token = authHeader.split(' ')[1];
+  if (token.startsWith('fake-jwt-token-for-user-')) {
+    const userId = parseInt(token.replace('fake-jwt-token-for-user-', ''));
+    const user = users.find(u => u.id === userId);
+    if (user) {
+      // Return a subset of user data for My Page
+      const { password, ...userProfile } = user;
+      return res.json(userProfile);
+    }
+  }
+
+  res.status(401).json({ error: 'Unauthorized: Invalid token' });
+});
+
+app.get('/', (req, res) => {
+  res.send('User service is running!');
+});
+
+app.listen(port, () => {
+  console.log(`User service listening at http://localhost:${port}`);
+});

--- a/services/user-service/package.json
+++ b/services/user-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gonggo/user-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
This commit introduces a complete backend architecture based on microservices within the existing monorepo.

The new architecture consists of 8 services:
- announcement-service
- company-service
- infra-service
- content-service
- consultation-service
- user-service
- admin-service
- gateway-service

Each service simulates a database with hardcoded mock data and includes commented-out SQL statements for schema and CRUD operations, as per the initial request.

An API gateway is included to provide a single entry point for all frontend requests, routing them to the appropriate downstream service.

The root package.json has been updated with scripts to install and run all services concurrently. A new README.md file documents the backend structure and usage.