### PR TITLE
chore: Update .gitignore for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,17 @@ yarn-error.log*
 logs
 *.log
 coverage/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.eggs/
+*.egg-info/
+*.egg


### PR DESCRIPTION
Adds standard Python patterns to the .gitignore file to prevent caching files, virtual environments, and other artifacts from being tracked by git.