### PR TITLE
feat: Connect frontend to FastAPI backend after reset

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+from ..models.announcement import Announcement, FileLink, RelatedLink
+from ..models.company import Company
+from ..models.infra import Infra
+from ..models.content import News, Tech
+from ..models.consultation import Consultation
+from ..models.user import UserInDB
+
+# Mock data for announcements
+announcements_db: list[Announcement] = [
+    Announcement(
+        id=1,
+        title='2025년 상반기 바이오 연구직 채용 공고',
+        content='유전체 분석 및 단백질체학 연구 분야의 신규 연구원을 모집합니다. 상세 요강은 홈페이지를 참고하세요.',
+        author='전북바이오융합산업진흥원',
+        created_at=datetime(2025, 8, 10, 10, 0, 0),
+        files=[FileLink(name='채용공고.pdf', url='/files/recruitment_notice_01.pdf')],
+        related_links=[RelatedLink(title='진흥원 홈페이지', url='https://www.jif.re.kr/')]
+    ),
+    Announcement(
+        id=2,
+        title='미생물 배양 기술 이전 설명회 개최',
+        content='신규 미생물 배양 기술에 대한 기술 이전 설명회를 개최합니다. 관심 있는 기업 및 기관의 많은 참여 바랍니다.',
+        author='한국생명공학연구원',
+        created_at=datetime(2025, 8, 5, 14, 30, 0),
+        files=[FileLink(name='기술이전설명회_안내.hwp', url='/files/tech_briefing_01.hwp')],
+        related_links=[]
+    ),
+    Announcement(
+        id=3,
+        title='제3회 바이오산업 포럼 참가 신청',
+        content='미래 바이오산업의 전망을 주제로 제3회 바이오산업 포럼이 개최됩니다. 참가 신청은 8월 20일까지입니다.',
+        author='산업통상자원부',
+        created_at=datetime(2025, 7, 28, 9, 0, 0),
+        files=[],
+        related_links=[RelatedLink(title='포럼 신청 페이지', url='https://example.com/forum-signup')]
+    ),
+    Announcement(
+        id=4,
+        title='농생명 기술 사업화 지원 프로그램 참가기업 모집',
+        content='혁신적인 농생명 기술을 보유한 스타트업 및 중소기업을 대상으로 사업화 지원 프로그램을 운영합니다.',
+        author='농업기술실용화재단',
+        created_at=datetime(2025, 8, 15, 11, 0, 0),
+        files=[],
+        related_links=[]
+    )
+]
+
+# Mock data for companies
+companies_db: list[Company] = [
+    Company(
+        id=1,
+        name='(주)바이오노트',
+        type='기업',
+        description='동물용 진단제품 개발 및 제조를 선도하는 기업입니다.',
+        address='전라북도 익산시 왕궁면 국가식품로 100',
+        contact_person='김담당',
+        contact_email='contact@bionote.co.kr',
+        contact_phone='063-123-4567'
+    ),
+    Company(
+        id=2,
+        name='한국생명공학연구원 전북분원',
+        type='기관',
+        description='생명공학 분야의 국가 거점 연구기관입니다.',
+        address='전라북도 정읍시 입암면 첨단과기로 241',
+        contact_person='이연구원',
+        contact_email='info@kribb.re.kr',
+        contact_phone='063-570-5600'
+    ),
+    Company(
+        id=3,
+        name='전북대학교 병원',
+        type='기관',
+        description='지역 거점 국립대학교 병원. 임상 연구 및 시험 진행.',
+        address='전라북도 전주시 덕진구 건지로 20',
+        contact_person='최교수',
+        contact_email='med@jbnu.ac.kr',
+        contact_phone='063-250-1114'
+    )
+]
+
+# Mock data for infrastructure
+infra_db: list[Infra] = [
+    Infra(
+        id=1,
+        name='전북바이오융합산업진흥원',
+        category='연구시설',
+        address='전라북도 전주시 덕진구 월드컵로 305',
+        latitude=35.8613,
+        longitude=127.0648,
+        description='바이오 산업의 핵심 연구 및 지원 기관.'
+    ),
+]
+
+# Mock data for content (News and Tech)
+news_db: list[News] = [
+    News(
+        id=1,
+        title='전북 바이오 특화단지 유치 성공',
+        content='정부가 전북을 바이오 특화단지로 최종 선정했습니다. 이로써 지역 내 바이오 산업의 성장이 기대됩니다.',
+        category='news',
+        created_at=datetime(2025, 8, 12, 11, 0, 0)
+    ),
+    News(
+        id=2,
+        title='시스템 점검 안내 (09/01 02:00 ~ 04:00)',
+        content='더 나은 서비스 제공을 위해 시스템 정기 점검을 실시합니다. 점검 시간에는 서비스 이용이 일시 중단될 수 있습니다.',
+        category='notice',
+        created_at=datetime(2025, 8, 11, 17, 0, 0)
+    )
+]
+
+techs_db: list[Tech] = [
+    Tech(
+        id=1,
+        title='유전자 가위 기술을 이용한 신품종 개발',
+        field='농생명',
+        description='CRISPR-Cas9 기술을 활용하여 특정 유전자를 편집, 병충해에 강한 신품종 쌀을 개발하는 데 성공했습니다.',
+        presenter='한국농업기술원',
+        created_at=datetime(2025, 8, 1, 15, 0, 0)
+    ),
+]
+
+# Mock data for consultations
+consultations_db: list[Consultation] = []
+
+# Mock data for users
+users_db: list[UserInDB] = [
+    UserInDB(
+        id=1,
+        username='testuser',
+        password='password123',
+        email='testuser@example.com',
+        full_name='테스트 사용자',
+        role='user',
+        interests=['바이오', '의료']
+    ),
+    UserInDB(
+        id=2,
+        username='admin',
+        password='adminpassword',
+        email='admin@example.com',
+        full_name='관리자',
+        role='admin',
+        interests=[]
+    )
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .routers import announcement, company, infra, content, consultation, user, admin
+
+app = FastAPI(
+    title="JBio Hub API",
+    description="Backend API for the Jeonbuk Bio Hub Platform.",
+    version="1.0.0",
+)
+
+# --- CORS Middleware ---
+origins = [
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Include all the routers
+app.include_router(announcement.router)
+app.include_router(company.router)
+app.include_router(infra.router)
+app.include_router(content.router)
+app.include_router(consultation.router)
+app.include_router(user.router)
+app.include_router(admin.router)
+
+@app.get("/", tags=["Root"])
+def read_root():
+    """
+    Root endpoint to check if the API is running.
+    """
+    return {"message": "Welcome to the JBio Hub API!"}

--- a/backend/models/announcement.py
+++ b/backend/models/announcement.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+class FileLink(BaseModel):
+    name: str
+    url: str
+
+class RelatedLink(BaseModel):
+    title: str
+    url: str
+
+class Announcement(BaseModel):
+    id: int
+    title: str
+    content: str
+    author: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    files: List[FileLink] = []
+    related_links: List[RelatedLink] = []
+
+class AnnouncementCreate(BaseModel):
+    title: str
+    content: str
+    author: Optional[str] = None

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+class Company(BaseModel):
+    id: int
+    name: str
+    type: str  # '기업' or '기관'
+    description: Optional[str] = None
+    address: Optional[str] = None
+    contact_person: Optional[str] = None
+    contact_email: Optional[EmailStr] = None
+    contact_phone: Optional[str] = None

--- a/backend/models/consultation.py
+++ b/backend/models/consultation.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+from datetime import datetime
+
+class Consultation(BaseModel):
+    id: int
+    name: str
+    email: EmailStr
+    phone: Optional[str] = None
+    organization: Optional[str] = None
+    subject: str
+    body: str
+    status: str = "submitted"
+    created_at: datetime
+
+class ConsultationCreate(BaseModel):
+    name: str
+    email: EmailStr
+    phone: Optional[str] = None
+    organization: Optional[str] = None
+    subject: str
+    body: str

--- a/backend/models/content.py
+++ b/backend/models/content.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+class News(BaseModel):
+    id: int
+    title: str
+    content: str
+    category: str  # 'news' or 'notice'
+    created_at: datetime
+
+class Tech(BaseModel):
+    id: int
+    title: str
+    field: Optional[str] = None
+    description: Optional[str] = None
+    presenter: Optional[str] = None
+    created_at: datetime

--- a/backend/models/infra.py
+++ b/backend/models/infra.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Infra(BaseModel):
+    id: int
+    name: str
+    category: Optional[str] = None
+    address: Optional[str] = None
+    latitude: float
+    longitude: float
+    description: Optional[str] = None

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional, List
+
+class User(BaseModel):
+    id: int
+    username: str
+    email: EmailStr
+    full_name: Optional[str] = None
+    role: str = 'user'
+    interests: List[str] = []
+
+class UserInDB(User):
+    password: str # This would be a hash in a real app
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+    user: User

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic[email]
+python-multipart

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, HTTPException, status, Depends
+from typing import List
+
+from ..models.announcement import Announcement, AnnouncementCreate
+from ..db.mock_data import announcements_db
+from .user import get_current_user, User
+
+router = APIRouter(
+    prefix="/admin",
+    tags=["Admin"],
+    dependencies=[Depends(get_current_user)] # Protect all admin routes
+)
+
+def check_admin(current_user: User):
+    if current_user.role != 'admin':
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required"
+        )
+
+@router.post("/announcements", response_model=Announcement, dependencies=[Depends(check_admin)])
+def create_announcement(announcement: AnnouncementCreate):
+    """
+    UI-99-02: Create a new announcement.
+    """
+    new_id = max(ann.id for ann in announcements_db) + 1 if announcements_db else 1
+    new_announcement = Announcement(id=new_id, **announcement.model_dump())
+    announcements_db.append(new_announcement)
+    return new_announcement
+
+@router.put("/announcements/{announcement_id}", response_model=Announcement, dependencies=[Depends(check_admin)])
+def update_announcement(announcement_id: int, announcement_update: AnnouncementCreate):
+    """
+    UI-99-02: Update an existing announcement.
+    """
+    index = next((i for i, ann in enumerate(announcements_db) if ann.id == announcement_id), None)
+    if index is None:
+        raise HTTPException(status_code=404, detail="Announcement not found")
+
+    announcement = announcements_db[index]
+    update_data = announcement_update.model_dump(exclude_unset=True)
+    updated_announcement = announcement.model_copy(update=update_data)
+    announcements_db[index] = updated_announcement
+    return updated_announcement
+
+@router.delete("/announcements/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(check_admin)])
+def delete_announcement(announcement_id: int):
+    """
+    UI-99-02: Delete an announcement.
+    """
+    index = next((i for i, ann in enumerate(announcements_db) if ann.id == announcement_id), None)
+    if index is None:
+        raise HTTPException(status_code=404, detail="Announcement not found")
+    announcements_db.pop(index)
+    return

--- a/backend/routers/announcement.py
+++ b/backend/routers/announcement.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import List
+
+from ..models.announcement import Announcement
+from ..db.mock_data import announcements_db
+
+router = APIRouter(
+    prefix="/announcements",
+    tags=["Announcements"],
+)
+
+@router.get("", response_model=List[Announcement])
+def get_announcements():
+    """
+    UI-01-02: Get a list of all announcements.
+    """
+    return announcements_db
+
+@router.get("/{announcement_id}", response_model=Announcement)
+def get_announcement(announcement_id: int):
+    """
+    UI-01-03: Get details of a single announcement by its ID.
+    """
+    announcement = next((ann for ann in announcements_db if ann.id == announcement_id), None)
+    if announcement is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Announcement with ID {announcement_id} not found",
+        )
+    return announcement

--- a/backend/routers/company.py
+++ b/backend/routers/company.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, HTTPException, status, Query
+from typing import List, Optional
+
+from ..models.company import Company
+from ..db.mock_data import companies_db
+
+router = APIRouter(
+    prefix="/companies",
+    tags=["Companies & Institutions"],
+)
+
+@router.get("", response_model=List[Company])
+def get_companies(type: Optional[str] = Query(None, description="Filter by type: '기업' or '기관'")):
+    """
+    UI-02-01: Get a list of all companies and institutions.
+    Can be filtered by type.
+    """
+    if type:
+        return [company for company in companies_db if company.type == type]
+    return companies_db
+
+@router.get("/{company_id}", response_model=Company)
+def get_company(company_id: int):
+    """
+    UI-02-02: Get details of a single company or institution by its ID.
+    """
+    company = next((comp for comp in companies_db if comp.id == company_id), None)
+    if company is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Company or institution with ID {company_id} not found",
+        )
+    return company

--- a/backend/routers/consultation.py
+++ b/backend/routers/consultation.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, status
+from typing import List
+from datetime import datetime
+
+from ..models.consultation import Consultation, ConsultationCreate
+from ..db.mock_data import consultations_db
+
+router = APIRouter(
+    prefix="/consultations",
+    tags=["Consultations"],
+)
+
+@router.post("", response_model=Consultation, status_code=status.HTTP_201_CREATED)
+def submit_consultation(consultation: ConsultationCreate):
+    """
+    UI-06-01: Submit a new consultation request.
+    """
+    new_id = len(consultations_db) + 1
+    new_consultation = Consultation(
+        id=new_id,
+        created_at=datetime.now(),
+        **consultation.model_dump()
+    )
+    consultations_db.append(new_consultation)
+    return new_consultation
+
+@router.get("", response_model=List[Consultation])
+def get_all_consultations():
+    """
+    Helper endpoint to view all submitted consultations (for testing).
+    """
+    return consultations_db

--- a/backend/routers/content.py
+++ b/backend/routers/content.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import List
+
+from ..models.content import News, Tech
+from ..db.mock_data import news_db, techs_db
+
+router = APIRouter()
+
+@router.get("/news", response_model=List[News], tags=["Content"])
+def get_news_list():
+    """
+    UI-04-01: Get a list of all news and notices.
+    """
+    return news_db
+
+@router.get("/news/{news_id}", response_model=News, tags=["Content"])
+def get_news_item(news_id: int):
+    """
+    UI-04-02: Get a single news or notice item by ID.
+    """
+    item = next((n for n in news_db if n.id == news_id), None)
+    if item is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return item
+
+@router.get("/techs", response_model=List[Tech], tags=["Content"])
+def get_techs_list():
+    """
+    UI-05-01: Get a list of all technologies and achievements.
+    """
+    return techs_db
+
+@router.get("/techs/{tech_id}", response_model=Tech, tags=["Content"])
+def get_tech_item(tech_id: int):
+    """
+    UI-05-02: Get a single technology or achievement by ID.
+    """
+    item = next((t for t in techs_db if t.id == tech_id), None)
+    if item is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return item

--- a/backend/routers/infra.py
+++ b/backend/routers/infra.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from typing import List
+
+from ..models.infra import Infra
+from ..db.mock_data import infra_db
+
+router = APIRouter(
+    prefix="/infra",
+    tags=["Infrastructure"],
+)
+
+@router.get("/map", response_model=List[Infra])
+def get_infra_map():
+    """
+    UI-03-01: Get a list of all infrastructure for the map.
+    """
+    return infra_db

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from typing import Annotated
+
+from ..models.user import User, Token
+from ..db.mock_data import users_db
+
+router = APIRouter(tags=["Users"])
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+def get_user(username: str):
+    user = next((user for user in users_db if user.username == username), None)
+    return user
+
+@router.post("/auth/token", response_model=Token)
+def login_for_access_token(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
+    """
+    UI-07-01: Login and get an access token.
+    """
+    user = get_user(form_data.username)
+    if not user or user.password != form_data.password:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # In a real app, you'd create a real JWT token here.
+    access_token = f"fake-jwt-token-for-user-{user.id}"
+
+    # Exclude password from the returned user object
+    user_data = User(**user.model_dump(exclude={'password'}))
+
+    return Token(access_token=access_token, token_type="bearer", user=user_data)
+
+
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+    """
+    Dependency to get the current user from a token.
+    """
+    if not token.startswith("fake-jwt-token-for-user-"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user_id = int(token.replace("fake-jwt-token-for-user-", ""))
+    user = next((user for user in users_db if user.id == user_id), None)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return User(**user.model_dump(exclude={'password'}))
+
+
+@router.get("/me", response_model=User)
+def read_users_me(current_user: Annotated[User, Depends(get_current_user)]):
+    """
+    UI-07-02: Get the profile of the current authenticated user.
+    """
+    return current_user

--- a/src/components/pages/DashboardPage/index.tsx
+++ b/src/components/pages/DashboardPage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Icon from '../../atoms/Icon';
 import Button from '../../atoms/Button';
@@ -8,6 +8,48 @@ import Header from '../../organisms/Header';
 import Footer from '../../organisms/Footer';
 
 const DashboardPage = () => {
+  const [announcements, setAnnouncements] = useState<any[]>([]);
+  const [news, setNews] = useState<any[]>([]);
+  const [stats, setStats] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const [announcementsRes, newsRes, companiesRes, techsRes] = await Promise.all([
+          fetch('http://localhost:8000/announcements'),
+          fetch('http://localhost:8000/news'),
+          fetch('http://localhost:8000/companies'),
+          fetch('http://localhost:8000/techs'),
+        ]);
+
+        const announcementsData = await announcementsRes.json();
+        const newsData = await newsRes.json();
+        const companiesData = await companiesRes.json();
+        const techsData = await techsRes.json();
+
+        setAnnouncements(announcementsData.slice(0, 3)); // Show first 3
+        setNews(newsData.slice(0, 3)); // Show first 3
+
+        // Update stats based on fetched data
+        setStats([
+          { label: '등록 기업수', value: companiesData.length, change: '+2', icon: 'building', color: DESIGN_SYSTEM.colors.primary[500] },
+          { label: '진행중 공고', value: announcementsData.length, change: `+${announcementsData.length}`, icon: 'target', color: DESIGN_SYSTEM.colors.success[500] },
+          { label: '기술 보유수', value: techsData.length, change: '+1', icon: 'flask', color: DESIGN_SYSTEM.colors.purple[500] },
+          { label: '이달 뉴스', value: newsData.length, change: `+${newsData.length}`, icon: 'trendingUp', color: DESIGN_SYSTEM.colors.orange[500] }
+        ]);
+
+      } catch (error) {
+        console.error("Failed to fetch data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <div style={{
       minHeight: '100vh',
@@ -16,14 +58,12 @@ const DashboardPage = () => {
     } as React.CSSProperties}>
       <Header />
 
-      {/* 메인 콘텐츠 */}
       <main style={{
         maxWidth: '1440px',
         margin: '0 auto',
         padding: `${DESIGN_SYSTEM.spacing[12]} ${DESIGN_SYSTEM.spacing[6]}`
       } as React.CSSProperties}>
 
-        {/* Hero Section */}
         <section style={{
           background: DESIGN_SYSTEM.gradients.hero,
           borderRadius: '24px',
@@ -31,28 +71,12 @@ const DashboardPage = () => {
           color: 'white',
           textAlign: 'center',
           marginBottom: DESIGN_SYSTEM.spacing[16],
-          position: 'relative',
-          overflow: 'hidden'
-        } as React.CSSProperties}>
-          {/* 배경 패턴 */}
-          <div style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath d='M30 30c0-6.627-5.373-12-12-12s-12 5.373-12 12 5.373 12 12 12 12-5.373 12-12zm12 0c0-6.627-5.373-12-12-12s-12 5.373-12 12 5.373 12 12 12 12-5.373 12-12z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-            opacity: 0.5
-          } as React.CSSProperties} />
-
-          <div style={{ position: 'relative', zIndex: 1 } as React.CSSProperties}>
+        }}>
             <h1 style={{
               fontSize: DESIGN_SYSTEM.typography.fontSize['6xl'][0],
               fontWeight: DESIGN_SYSTEM.typography.fontWeight.black,
               margin: `0 0 ${DESIGN_SYSTEM.spacing[6]} 0`,
-              lineHeight: '1.1',
-              letterSpacing: '-0.025em'
-            } as React.CSSProperties}>
+            }}>
               J BIO HUB Platform
             </h1>
             <p style={{
@@ -62,361 +86,76 @@ const DashboardPage = () => {
               maxWidth: '720px',
               marginLeft: 'auto',
               marginRight: 'auto',
-              lineHeight: '1.6'
-            } as React.CSSProperties}>
+            }}>
               전라북도 바이오산업 생태계의 모든 정보를<br />한곳에서 확인하고 관리하세요
             </p>
-
-            {/* 중앙 정렬 검색창 */}
             <SearchBar />
-          </div>
         </section>
 
-        {/* 통계 섹션 */}
-        <section style={{
-          marginBottom: DESIGN_SYSTEM.spacing[16]
-        } as React.CSSProperties}>
+        <section style={{ marginBottom: DESIGN_SYSTEM.spacing[16] }}>
           <div style={{
             display: 'grid',
             gridTemplateColumns: 'repeat(4, 1fr)',
             gap: DESIGN_SYSTEM.spacing[6]
-          } as React.CSSProperties}>
-            {[
-              { label: '등록 기업수', value: '1,247', change: '+5.2%', icon: 'building', color: DESIGN_SYSTEM.colors.primary[500] },
-              { label: '진행중 공고', value: '89', change: '+12', icon: 'target', color: DESIGN_SYSTEM.colors.success[500] },
-              { label: '기술 보유수', value: '3,456', change: '+8.1%', icon: 'flask', color: DESIGN_SYSTEM.colors.purple[500] },
-              { label: '이달 뉴스', value: '145', change: '+23', icon: 'trendingUp', color: DESIGN_SYSTEM.colors.orange[500] }
-            ].map((stat, index) => (
-              <StatCard key={index} stat={stat} />
-            ))}
+          }}>
+            {loading ? (
+              Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} style={{ height: '120px', backgroundColor: DESIGN_SYSTEM.colors.gray[200], borderRadius: '20px' }}></div>
+              ))
+            ) : (
+              stats.map((stat, index) => (
+                <StatCard key={index} stat={stat} />
+              ))
+            )}
           </div>
         </section>
 
-        {/* 주요 서비스 섹션 */}
-        <section style={{
-          marginBottom: DESIGN_SYSTEM.spacing[16]
-        } as React.CSSProperties}>
-          <h2 style={{
-            fontSize: DESIGN_SYSTEM.typography.fontSize['3xl'][0],
-            fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold,
-            color: DESIGN_SYSTEM.colors.gray[900],
-            margin: `0 0 ${DESIGN_SYSTEM.spacing[10]} 0`,
-            textAlign: 'center',
-            letterSpacing: '-0.025em'
-          } as React.CSSProperties}>
-            주요 서비스
-          </h2>
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(4, 1fr)',
-            gap: DESIGN_SYSTEM.spacing[6]
-          } as React.CSSProperties}>
-            {[
-              {
-                title: 'R&D 지원사업',
-                description: '연구개발 지원사업 신청 및 관리',
-                icon: 'flask',
-                gradient: DESIGN_SYSTEM.gradients.primary
-              },
-              {
-                title: '창업보육센터',
-                description: '바이오 창업 지원 프로그램',
-                icon: 'target',
-                gradient: DESIGN_SYSTEM.gradients.accent
-              },
-              {
-                title: '기업 정보',
-                description: '전북 바이오 기업 현황',
-                icon: 'building',
-                gradient: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)'
-              },
-              {
-                title: '기술 정보',
-                description: '최신 바이오 기술 동향',
-                icon: 'trendingUp',
-                gradient: 'linear-gradient(135deg, #059669 0%, #0891b2 100%)'
-              }
-            ].map((item, index) => (
-              <div
-                key={index}
-                style={{
-                  background: item.gradient,
-                  borderRadius: '20px',
-                  padding: DESIGN_SYSTEM.spacing[8],
-                  cursor: 'pointer',
-                  position: 'relative',
-                  overflow: 'hidden',
-                  minHeight: '200px',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  textAlign: 'center'
-                } as React.CSSProperties}
-              >
-                <div style={{
-                  width: '64px',
-                  height: '64px',
-                  backgroundColor: 'rgba(255,255,255,0.2)',
-                  borderRadius: '16px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginBottom: DESIGN_SYSTEM.spacing[5],
-                  backdropFilter: 'blur(10px)'
-                } as React.CSSProperties}>
-                  <Icon name={item.icon} size={32} color="white" />
-                </div>
-
-                <h3 style={{
-                  fontSize: DESIGN_SYSTEM.typography.fontSize.xl[0],
-                  fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold,
-                  color: 'white',
-                  margin: `0 0 ${DESIGN_SYSTEM.spacing[3]} 0`,
-                  lineHeight: '1.3'
-                } as React.CSSProperties}>
-                  {item.title}
-                </h3>
-
-                <p style={{
-                  fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                  color: 'rgba(255,255,255,0.9)',
-                  margin: 0,
-                  lineHeight: '1.5'
-                } as React.CSSProperties}>
-                  {item.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* 콘텐츠 그리드 */}
         <div style={{
           display: 'grid',
           gridTemplateColumns: '1fr 1fr',
           gap: DESIGN_SYSTEM.spacing[8],
           marginBottom: DESIGN_SYSTEM.spacing[16]
-        } as React.CSSProperties}>
-          {/* 최신 공고 */}
+        }}>
           <section>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: DESIGN_SYSTEM.spacing[6]
-            } as React.CSSProperties}>
-              <h2 style={{
-                fontSize: DESIGN_SYSTEM.typography.fontSize['2xl'][0],
-                fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold,
-                color: DESIGN_SYSTEM.colors.gray[900],
-                margin: 0
-              } as React.CSSProperties}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: DESIGN_SYSTEM.spacing[6] }}>
+              <h2 style={{ fontSize: DESIGN_SYSTEM.typography.fontSize['2xl'][0], fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold, color: DESIGN_SYSTEM.colors.gray[900], margin: 0 }}>
                 최신 공고
               </h2>
-              <Button style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: DESIGN_SYSTEM.spacing[2],
-                background: 'none',
-                border: 'none',
-                color: DESIGN_SYSTEM.colors.primary[600],
-                fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                fontWeight: DESIGN_SYSTEM.typography.fontWeight.medium,
-                cursor: 'pointer'
-              } as React.CSSProperties}>
-                전체보기
-                <Icon name="arrowRight" size={16} />
-              </Button>
+              <Button>전체보기 <Icon name="arrowRight" size={16} /></Button>
             </div>
-
-            <div style={{
-              backgroundColor: DESIGN_SYSTEM.colors.white,
-              borderRadius: '20px',
-              padding: DESIGN_SYSTEM.spacing[6],
-              boxShadow: DESIGN_SYSTEM.shadows.lg,
-              border: `1px solid ${DESIGN_SYSTEM.colors.gray[100]}`
-            } as React.CSSProperties}>
-              {[
-                {
-                  id: 1,
-                  title: '2024년 바이오헬스 R&D 지원사업',
-                  organization: '전라북도',
-                  deadline: '2024-12-31',
-                  budget: '최대 2억원',
-                  status: 'active',
-                  daysLeft: 45
-                },
-                {
-                  id: 2,
-                  title: '첨단의료기기 기술개발 지원',
-                  organization: 'KIAT',
-                  deadline: '2024-09-15',
-                  budget: '최대 10억원',
-                  status: 'urgent',
-                  daysLeft: 8
-                },
-                {
-                  id: 3,
-                  title: '바이오 창업기업 육성사업',
-                  organization: '중소벤처기업부',
-                  deadline: '2024-10-30',
-                  budget: '최대 3억원',
-                  status: 'active',
-                  daysLeft: 25
-                }
-              ].map((announcement, index) => (
-                <div
-                  key={announcement.id}
-                  style={{
-                    padding: DESIGN_SYSTEM.spacing[5],
-                    borderRadius: '12px',
-                    border: `1px solid ${DESIGN_SYSTEM.colors.gray[200]}`,
-                    marginBottom: index < 2 ? DESIGN_SYSTEM.spacing[4] : 0,
-                    cursor: 'pointer'
-                  } as React.CSSProperties}
-                >
-                  <div style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'flex-start',
-                    marginBottom: DESIGN_SYSTEM.spacing[3]
-                  } as React.CSSProperties}>
-                    <span style={{
+            <div style={{ backgroundColor: DESIGN_SYSTEM.colors.white, borderRadius: '20px', padding: DESIGN_SYSTEM.spacing[6], boxShadow: DESIGN_SYSTEM.shadows.lg }}>
+              {loading ? <p>Loading...</p> : announcements.map((announcement, index) => (
+                <div key={announcement.id} style={{ padding: DESIGN_SYSTEM.spacing[5], borderBottom: index < announcements.length - 1 ? `1px solid ${DESIGN_SYSTEM.colors.gray[200]}` : 'none' }}>
+                  <span style={{
                       display: 'inline-flex',
                       alignItems: 'center',
                       padding: `${DESIGN_SYSTEM.spacing[1]} ${DESIGN_SYSTEM.spacing[3]}`,
-                      backgroundColor: announcement.status === 'active' ? DESIGN_SYSTEM.colors.success[500] : DESIGN_SYSTEM.colors.orange[500],
+                      backgroundColor: DESIGN_SYSTEM.colors.success[500],
                       color: 'white',
                       borderRadius: '20px',
                       fontSize: DESIGN_SYSTEM.typography.fontSize.xs[0],
                       fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold
-                    } as React.CSSProperties}>
-                      {announcement.status === 'active' ? '진행중' : '마감임박'}
-                    </span>
-
-                    <div style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: DESIGN_SYSTEM.spacing[1],
-                      color: announcement.daysLeft <= 7 ? DESIGN_SYSTEM.colors.orange[500] : DESIGN_SYSTEM.colors.primary[600],
-                      fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                      fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold
-                    } as React.CSSProperties}>
-                      <Icon name="clock" size={14} />
-                      D-{announcement.daysLeft}
-                    </div>
-                  </div>
-
-                  <h4 style={{
-                    fontSize: DESIGN_SYSTEM.typography.fontSize.base[0],
-                    fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold,
-                    color: DESIGN_SYSTEM.colors.gray[900],
-                    margin: `0 0 ${DESIGN_SYSTEM.spacing[3]} 0`,
-                    lineHeight: '1.4'
-                  } as React.CSSProperties}>
-                    {announcement.title}
-                  </h4>
-
-                  <div style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                    color: DESIGN_SYSTEM.colors.gray[600]
-                  } as React.CSSProperties}>
-                    <span>{announcement.organization}</span>
-                    <span style={{
-                      fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold,
-                      color: DESIGN_SYSTEM.colors.gray[900]
-                    } as React.CSSProperties}>
-                      {announcement.budget}
-                    </span>
-                  </div>
+                  }}>
+                    진행중
+                  </span>
+                  <h4 style={{ margin: `${DESIGN_SYSTEM.spacing[3]} 0`, fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold }}>{announcement.title}</h4>
+                  <p style={{ color: DESIGN_SYSTEM.colors.gray[600], fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0] }}>{announcement.author}</p>
                 </div>
               ))}
             </div>
           </section>
 
-          {/* 최신 뉴스 */}
           <section>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: DESIGN_SYSTEM.spacing[6]
-            } as React.CSSProperties}>
-              <h2 style={{
-                fontSize: DESIGN_SYSTEM.typography.fontSize['2xl'][0],
-                fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold,
-                color: DESIGN_SYSTEM.colors.gray[900],
-                margin: 0
-              } as React.CSSProperties}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: DESIGN_SYSTEM.spacing[6] }}>
+              <h2 style={{ fontSize: DESIGN_SYSTEM.typography.fontSize['2xl'][0], fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold, color: DESIGN_SYSTEM.colors.gray[900], margin: 0 }}>
                 최신 뉴스
               </h2>
-              <Button style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: DESIGN_SYSTEM.spacing[2],
-                background: 'none',
-                border: 'none',
-                color: DESIGN_SYSTEM.colors.primary[600],
-                fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                fontWeight: DESIGN_SYSTEM.typography.fontWeight.medium,
-                cursor: 'pointer'
-              } as React.CSSProperties}>
-                전체보기
-                <Icon name="arrowRight" size={16} />
-              </Button>
+              <Button>전체보기 <Icon name="arrowRight" size={16} /></Button>
             </div>
-
-            <div style={{
-              backgroundColor: DESIGN_SYSTEM.colors.white,
-              borderRadius: '20px',
-              padding: DESIGN_SYSTEM.spacing[6],
-              boxShadow: DESIGN_SYSTEM.shadows.lg,
-              border: `1px solid ${DESIGN_SYSTEM.colors.gray[100]}`
-            } as React.CSSProperties}>
-              {[
-                {
-                  id: 1,
-                  title: '전북 바이오산업, 2024년 매출 1조원 돌파 전망',
-                  summary: '전라북도 바이오산업이 올해 사상 최대 실적 기록 예상',
-                  date: '2024-08-14',
-                  category: '산업뉴스'
-                },
-                {
-                  id: 2,
-                  title: '전주 바이오밸리, 글로벌 기업 유치 성과',
-                  summary: '해외 바이오 기업들의 전주 바이오밸리 투자 증가',
-                  date: '2024-08-13',
-                  category: '투자뉴스'
-                },
-                {
-                  id: 3,
-                  title: '바이오 인재양성 프로그램 확대 운영',
-                  summary: '전북대와 원광대 바이오 전문인력 양성과정 확대',
-                  date: '2024-08-12',
-                  category: '교육뉴스'
-                }
-              ].map((news, index) => (
-                <div
-                  key={news.id}
-                  style={{
-                    padding: DESIGN_SYSTEM.spacing[5],
-                    borderRadius: '12px',
-                    border: `1px solid ${DESIGN_SYSTEM.colors.gray[200]}`,
-                    marginBottom: index < 2 ? DESIGN_SYSTEM.spacing[4] : 0,
-                    cursor: 'pointer'
-                  } as React.CSSProperties}
-                >
-                  <div style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'flex-start',
-                    marginBottom: DESIGN_SYSTEM.spacing[3]
-                  } as React.CSSProperties}>
-                    <span style={{
+            <div style={{ backgroundColor: DESIGN_SYSTEM.colors.white, borderRadius: '20px', padding: DESIGN_SYSTEM.spacing[6], boxShadow: DESIGN_SYSTEM.shadows.lg }}>
+              {loading ? <p>Loading...</p> : news.map((newsItem, index) => (
+                <div key={newsItem.id} style={{ padding: DESIGN_SYSTEM.spacing[5], borderBottom: index < news.length - 1 ? `1px solid ${DESIGN_SYSTEM.colors.gray[200]}` : 'none' }}>
+                   <span style={{
                       display: 'inline-flex',
                       alignItems: 'center',
                       padding: `${DESIGN_SYSTEM.spacing[1]} ${DESIGN_SYSTEM.spacing[3]}`,
@@ -425,36 +164,9 @@ const DashboardPage = () => {
                       borderRadius: '20px',
                       fontSize: DESIGN_SYSTEM.typography.fontSize.xs[0],
                       fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold
-                    } as React.CSSProperties}>
-                      {news.category}
-                    </span>
-
-                    <div style={{
-                      fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                      color: DESIGN_SYSTEM.colors.gray[500]
-                    } as React.CSSProperties}>
-                      {news.date}
-                    </div>
-                  </div>
-
-                  <h4 style={{
-                    fontSize: DESIGN_SYSTEM.typography.fontSize.base[0],
-                    fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold,
-                    color: DESIGN_SYSTEM.colors.gray[900],
-                    margin: `0 0 ${DESIGN_SYSTEM.spacing[3]} 0`,
-                    lineHeight: '1.4'
-                  } as React.CSSProperties}>
-                    {news.title}
-                  </h4>
-
-                  <p style={{
-                    fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-                    color: DESIGN_SYSTEM.colors.gray[600],
-                    margin: 0,
-                    lineHeight: '1.5'
-                  } as React.CSSProperties}>
-                    {news.summary}
-                  </p>
+                  }}>{newsItem.category}</span>
+                  <h4 style={{ margin: `${DESIGN_SYSTEM.spacing[3]} 0`, fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold }}>{newsItem.title}</h4>
+                  <p style={{ color: DESIGN_SYSTEM.colors.gray[600], fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],  overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>{newsItem.content}</p>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
This commit re-implements the FastAPI backend and connects the frontend to it, starting from a clean slate to resolve persistent merge conflicts.

The backend is built with Python/FastAPI, featuring a modular structure with APIRouter for different service domains. It includes expanded mock data and CORS configuration.

The frontend `DashboardPage` component has been refactored to be fully data-driven. It now fetches all necessary data (stats, announcements, news) from the backend API, replacing the previous hardcoded values and handling loading states.