### PR TITLE
feat: Create Announcement Detail Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import IncubationPage from './components/pages/IncubationPage';
 import NewsEventsPage from './components/pages/NewsEventsPage';
 import CompaniesPage from './components/pages/CompaniesPage';
 import TechPatentsPage from './components/pages/TechPatentsPage';
+import AnnouncementDetailPage from './components/pages/AnnouncementDetailPage';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
       <Route path="/" element={<HomePage />} />
       <Route path="/cluster" element={<ClusterPage />} />
       <Route path="/announcements" element={<AnnouncementsPage />} />
+      <Route path="/support/:category/:announcementId" element={<AnnouncementDetailPage />} />
       <Route path="/incubation" element={<IncubationPage />} />
       <Route path="/news-events" element={<NewsEventsPage />} />
       <Route path="/companies" element={<CompaniesPage />} />

--- a/src/components/molecules/AttachmentList/index.tsx
+++ b/src/components/molecules/AttachmentList/index.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import styled from 'styled-components';
+import Icon from '../../atoms/Icon';
+
+// --- STYLED COMPONENTS ---
+
+const ListContainer = styled.div`
+  border: 1px solid #e5e7eb; /* gray-200 */
+  border-radius: 12px;
+`;
+
+const ListItem = styled.a`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: background-color 0.2s ease-in-out;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid #e5e7eb; /* gray-200 */
+  }
+
+  &:hover {
+    background-color: #f9fafb; /* gray-50 */
+
+    .file-name-span {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const FileInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+const FileName = styled.span.attrs({
+  className: 'file-name-span'
+})`
+  font-weight: 500;
+  color: #111827; /* gray-900 */
+`;
+
+const FileSize = styled.span`
+  font-size: 0.875rem;
+  color: #6b7280; /* gray-500 */
+`;
+
+// --- DATA MODELS ---
+
+interface Attachment {
+  fileName: string;
+  fileUrl: string;
+  fileSize: string;
+}
+
+interface AttachmentListProps {
+  title: string;
+  attachments: Attachment[];
+}
+
+// --- COMPONENT ---
+
+const AttachmentList: React.FC<AttachmentListProps> = ({ title, attachments }) => {
+  return (
+    <section>
+      <h3 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}>{title}</h3>
+      <ListContainer>
+        {attachments.map((file, index) => (
+          <ListItem key={index} href={file.fileUrl} download>
+            <FileInfo>
+              <Icon name="file" size={20} color="#6b7280" />
+              <FileName>{file.fileName}</FileName>
+              <FileSize>({file.fileSize})</FileSize>
+            </FileInfo>
+            <Icon name="download" size={20} color="#6b7280" />
+          </ListItem>
+        ))}
+      </ListContainer>
+    </section>
+  );
+};
+
+export default AttachmentList;

--- a/src/components/molecules/InfoTable/index.tsx
+++ b/src/components/molecules/InfoTable/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// --- STYLED COMPONENTS ---
+
+const TableContainer = styled.div`
+  overflow-x: auto;
+  border: 1px solid #e5e7eb; /* gray-200 */
+  border-radius: 12px;
+`;
+
+const StyledTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem; /* text-sm */
+`;
+
+const THead = styled.thead``;
+
+const TBody = styled.tbody``;
+
+const Tr = styled.tr`
+  &:not(:last-child) {
+    border-bottom: 1px solid #e5e7eb; /* gray-200 */
+  }
+`;
+
+const Th = styled.th`
+  background-color: #f9fafb; /* gray-50 */
+  padding: 0.75rem 1.5rem;
+  text-align: left;
+  font-weight: 600; /* semibold */
+  color: #374151; /* gray-700 */
+  width: 180px; /* Fixed width for headers */
+`;
+
+const Td = styled.td`
+  padding: 0.75rem 1.5rem;
+  color: #111827; /* gray-900 */
+
+  &.emphasized {
+    color: #E53935;
+    font-weight: 500;
+  }
+`;
+
+// --- COMPONENT ---
+
+interface InfoTableProps {
+  title: string;
+  data: { [key: string]: string | React.ReactNode };
+}
+
+const InfoTable: React.FC<InfoTableProps> = ({ title, data }) => {
+  return (
+    <section>
+      <h3 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}>{title}</h3>
+      <TableContainer>
+        <StyledTable>
+          <TBody>
+            {Object.entries(data).map(([key, value]) => (
+              <Tr key={key}>
+                <Th>{key}</Th>
+                <Td className={key === '신청기간' ? 'emphasized' : ''}>{value}</Td>
+              </Tr>
+            ))}
+          </TBody>
+        </StyledTable>
+      </TableContainer>
+    </section>
+  );
+};
+
+export default InfoTable;

--- a/src/components/pages/AnnouncementDetailPage/index.tsx
+++ b/src/components/pages/AnnouncementDetailPage/index.tsx
@@ -1,19 +1,211 @@
 import React from 'react';
+import styled from 'styled-components';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import MainLayout from '../../templates/MainLayout';
+import InfoTable from '../../molecules/InfoTable';
+import AttachmentList from '../../molecules/AttachmentList';
+import Icon from '../../atoms/Icon';
+import Button from '../../atoms/Button';
 
-/**
- * ## UI-01-03: Announcement Detail Page
- * ### Atomic Structure
- * - Template: MainLayout
- * - Organism: AnnouncementDetail (to be created)
- *
- * @returns {JSX.Element}
- */
+// --- MOCK DATA ---
+const mockAnnouncement = {
+  announcementTitle: '[JB-Bio] 2024년 바이오 스타트업 성장 지원 프로그램 참여기업 모집',
+  industryField: '바이오/헬스케어',
+  businessType: '기술개발',
+  companyType: '예비창업자, 스타트업',
+  announcementDate: '2024-07-15',
+  applicationStartDate: '2024-07-20 09:00',
+  applicationEndDate: '2024-08-20 18:00',
+  productCode: 'JB-BIO-2024-001',
+  organizationName: '전북바이오융합산업진흥원',
+  organizationDept: '기업지원단',
+  contactName: '김담당',
+  contactPhone: '063-123-4567',
+  descriptionHTML: `
+    <h2>사업목적</h2>
+    <p>도내 바이오 스타트업의 성장을 촉진하고, 글로벌 경쟁력을 갖춘 기업으로 육성하기 위함.</p>
+    <br/>
+    <h2>지원내용</h2>
+    <p>1. 사업화 자금 지원 (최대 5,000만원)</p>
+    <p>2. 전문 멘토링 및 컨설팅</p>
+    <p>3. 전북바이오융합산업진흥원 인프라(장비, 시설) 이용 지원</p>
+    <br/>
+    <p>자세한 내용은 첨부된 공고문을 확인해주시기 바랍니다.</p>
+    <p>관련 링크: <a href="https://www.jif.re.kr/" target="_blank" rel="noopener noreferrer">전북바이오융합산업진흥원 홈페이지</a></p>
+    <img src="https://via.placeholder.com/800x400.png?text=Sample+Image" alt="Sample Image" style="max-width: 100%; border-radius: 8px; margin-top: 1rem;" />
+  `,
+  attachments: [
+    { fileName: '2024년 바이오 스타트업 성장 지원 프로그램 공고문.hwp', fileUrl: '#', fileSize: '1.2MB' },
+    { fileName: '사업계획서 양식.zip', fileUrl: '#', fileSize: '850KB' },
+    { fileName: '제출서류 목록.pdf', fileUrl: '#', fileSize: '300KB' },
+  ],
+};
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const Breadcrumb = styled.nav`
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-bottom: 1rem;
+
+  a {
+    color: #4f46e5;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  span {
+    margin: 0 0.5rem;
+  }
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid #111827;
+  padding-bottom: 1.5rem;
+`;
+
+const SectionWrapper = styled.div`
+  margin-bottom: 2.5rem;
+`;
+
+const HtmlContent = styled.div`
+  padding: 1.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  line-height: 1.6;
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 1rem 0;
+  }
+  p {
+    margin-bottom: 1rem;
+  }
+  a {
+    color: #4f46e5;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const InfoText = styled.div`
+  background-color: #f9fafb;
+  padding: 1.5rem;
+  border-radius: 12px;
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.5;
+  margin-top: 2.5rem;
+
+  p {
+    margin: 0;
+    &:not(:last-child) {
+      margin-bottom: 0.5rem;
+    }
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 3rem;
+`;
+
+const BackButton = styled(Button)`
+  background-color: #4b5563;
+  color: white;
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #374151;
+  }
+`;
+
+// --- COMPONENT ---
+
 const AnnouncementDetailPage = () => {
+  const { category, announcementId } = useParams();
+  const navigate = useNavigate();
+
+  const announcementInfo = {
+    '산업분야': mockAnnouncement.industryField,
+    '사업구분': mockAnnouncement.businessType,
+    '기업유형': mockAnnouncement.companyType,
+    '공고일': mockAnnouncement.announcementDate,
+    '신청기간': `${mockAnnouncement.applicationStartDate} ~ ${mockAnnouncement.applicationEndDate}`,
+    '품목코드': mockAnnouncement.productCode,
+  };
+
+  const organizationInfo = {
+    '전담기관': mockAnnouncement.organizationName,
+    '전담부서': mockAnnouncement.organizationDept,
+    '담당자명': mockAnnouncement.contactName,
+    '담당자 연락처': mockAnnouncement.contactPhone,
+  };
+
   return (
     <MainLayout>
-      <h1>공고 상세</h1>
-      {/* TODO: Implement AnnouncementDetail organism */}
+      <PageWrapper>
+        <Breadcrumb>
+          <Link to="/">Home</Link>
+          <span>&gt;</span>
+          <Link to="/announcements">{category}</Link>
+          <span>&gt;</span>
+          <span>{mockAnnouncement.announcementTitle}</span>
+        </Breadcrumb>
+
+        <PageTitle>{mockAnnouncement.announcementTitle}</PageTitle>
+
+        <SectionWrapper>
+          <InfoTable title="공고 정보" data={announcementInfo} />
+        </SectionWrapper>
+
+        <SectionWrapper>
+          <InfoTable title="전담기관 정보" data={organizationInfo} />
+        </SectionWrapper>
+
+        <SectionWrapper>
+          <h3 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}>상세 정보</h3>
+          <HtmlContent dangerouslySetInnerHTML={{ __html: mockAnnouncement.descriptionHTML }} />
+        </SectionWrapper>
+
+        <SectionWrapper>
+          <AttachmentList title="첨부문서" attachments={mockAnnouncement.attachments} />
+        </SectionWrapper>
+
+        <InfoText>
+          <p>※ 사업안내 내용을 반드시 숙지하시고 사업 신청을 하시기 바랍니다.</p>
+          <p>※ 본 사업은 기업 회원만 신청 가능합니다. 로그인 후 신청해주세요.</p>
+        </InfoText>
+
+        <ButtonContainer>
+          <BackButton onClick={() => navigate(-1)}>
+            <Icon name="arrowLeft" size={16} color="white" />
+            <span style={{ marginLeft: '0.5rem' }}>뒤로가기</span>
+          </BackButton>
+        </ButtonContainer>
+      </PageWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
Implements the new Announcement Detail Page based on the detailed work order.

- Adds a new route for `/support/:category/:announcementId`.
- Creates the `AnnouncementDetailPage` page component.
- Creates reusable `InfoTable` and `AttachmentList` molecule components.
- Implements the entire feature using `styled-components` for styling.
- The page is fully responsive and uses mock data for initial rendering.