### PR TITLE
feat: Connect announcement list and detail pages

### DIFF
--- a/src/components/molecules/AnnouncementListItem/index.tsx
+++ b/src/components/molecules/AnnouncementListItem/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import styled from 'styled-components';
 import Icon from '../../atoms/Icon';
 
+// --- DATA MODELS ---
 interface Announcement {
   id: number;
   title: string;
@@ -17,75 +18,91 @@ interface AnnouncementListItemProps {
   style?: React.CSSProperties;
 }
 
+// --- STYLED COMPONENTS ---
+
+const ItemWrapper = styled.div`
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+
+  &:hover {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+    border-color: #d1d5db;
+  }
+`;
+
+const ItemHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+`;
+
+const StatusBadge = styled.span<{ status: 'active' | 'urgent' }>`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  background-color: ${props => props.status === 'active' ? '#10b981' : '#f59e0b'};
+  color: white;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+`;
+
+const DaysLeft = styled.div<{ days: number }>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: ${props => props.days <= 7 ? '#f59e0b' : '#4f46e5'};
+  font-size: 0.875rem;
+  font-weight: 700;
+`;
+
+const ItemTitle = styled.h4`
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 0.75rem 0;
+  line-height: 1.4;
+`;
+
+const ItemFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+`;
+
+const Organization = styled.span``;
+const Budget = styled.span`
+  font-weight: 600;
+  color: #111827;
+`;
+
+
+// --- COMPONENT ---
+
 const AnnouncementListItem: React.FC<AnnouncementListItemProps> = ({ announcement, style }) => {
   return (
-    <div
-      style={{
-        padding: DESIGN_SYSTEM.spacing[5],
-        borderRadius: '12px',
-        border: `1px solid ${DESIGN_SYSTEM.colors.gray[200]}`,
-        cursor: 'pointer',
-        ...style
-      }}
-    >
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
-        marginBottom: DESIGN_SYSTEM.spacing[3]
-      } as React.CSSProperties}>
-        <span style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          padding: `${DESIGN_SYSTEM.spacing[1]} ${DESIGN_SYSTEM.spacing[3]}`,
-          backgroundColor: announcement.status === 'active' ? DESIGN_SYSTEM.colors.success[500] : DESIGN_SYSTEM.colors.orange[500],
-          color: 'white',
-          borderRadius: '20px',
-          fontSize: DESIGN_SYSTEM.typography.fontSize.xs[0],
-          fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold
-        } as React.CSSProperties}>
+    <ItemWrapper style={style}>
+      <ItemHeader>
+        <StatusBadge status={announcement.status}>
           {announcement.status === 'active' ? '진행중' : '마감임박'}
-        </span>
-
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: DESIGN_SYSTEM.spacing[1],
-          color: announcement.daysLeft <= 7 ? DESIGN_SYSTEM.colors.orange[500] : DESIGN_SYSTEM.colors.primary[600],
-          fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-          fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold
-        } as React.CSSProperties}>
+        </StatusBadge>
+        <DaysLeft days={announcement.daysLeft}>
           <Icon name="clock" size={14} />
           D-{announcement.daysLeft}
-        </div>
-      </div>
-
-      <h4 style={{
-        fontSize: DESIGN_SYSTEM.typography.fontSize.base[0],
-        fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold,
-        color: DESIGN_SYSTEM.colors.gray[900],
-        margin: `0 0 ${DESIGN_SYSTEM.spacing[3]} 0`,
-        lineHeight: '1.4'
-      } as React.CSSProperties}>
-        {announcement.title}
-      </h4>
-
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        fontSize: DESIGN_SYSTEM.typography.fontSize.sm[0],
-        color: DESIGN_SYSTEM.colors.gray[600]
-      } as React.CSSProperties}>
-        <span>{announcement.organization}</span>
-        <span style={{
-          fontWeight: DESIGN_SYSTEM.typography.fontWeight.semibold,
-          color: DESIGN_SYSTEM.colors.gray[900]
-        } as React.CSSProperties}>
-          {announcement.budget}
-        </span>
-      </div>
-    </div>
+        </DaysLeft>
+      </ItemHeader>
+      <ItemTitle>{announcement.title}</ItemTitle>
+      <ItemFooter>
+        <Organization>{announcement.organization}</Organization>
+        <Budget>{announcement.budget}</Budget>
+      </ItemFooter>
+    </ItemWrapper>
   );
 };
 

--- a/src/components/organisms/AnnouncementList/index.tsx
+++ b/src/components/organisms/AnnouncementList/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import AnnouncementListItem from '../../molecules/AnnouncementListItem';
-import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
-// TODO: Define this interface in a shared types file
+// --- DATA MODELS ---
 interface Announcement {
   id: number;
   title: string;
@@ -18,17 +19,29 @@ interface AnnouncementListProps {
   style?: React.CSSProperties;
 }
 
+// --- STYLED COMPONENTS ---
+const ListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const ItemLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+`;
+
+// --- COMPONENT ---
+
 const AnnouncementList: React.FC<AnnouncementListProps> = ({ announcements, style }) => {
   return (
-    <div style={style}>
-      {announcements.map((announcement, index) => (
-        <AnnouncementListItem
-          key={announcement.id}
-          announcement={announcement}
-          style={{ marginBottom: index < announcements.length - 1 ? DESIGN_SYSTEM.spacing[4] : 0 }}
-        />
+    <ListWrapper style={style}>
+      {announcements.map((announcement) => (
+        <ItemLink key={announcement.id} to={`/support/announcements/${announcement.id}`}>
+          <AnnouncementListItem announcement={announcement} />
+        </ItemLink>
       ))}
-    </div>
+    </ListWrapper>
   );
 };
 

--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '../../atoms/Button';
 import Icon from '../../atoms/Icon';
@@ -193,10 +194,12 @@ const ContentGrid = () => {
       <Section>
         <SectionHeader>
           <SectionTitle>최신 공고</SectionTitle>
-          <ViewAllButton>
-            전체보기
-            <Icon name="arrowRight" size={16} />
-          </ViewAllButton>
+          <Link to="/announcements" style={{ textDecoration: 'none' }}>
+            <ViewAllButton>
+              전체보기
+              <Icon name="arrowRight" size={16} />
+            </ViewAllButton>
+          </Link>
         </SectionHeader>
 
         <CardContainer>
@@ -208,10 +211,12 @@ const ContentGrid = () => {
       <Section>
         <SectionHeader>
           <SectionTitle>최신 뉴스</SectionTitle>
-          <ViewAllButton>
-            전체보기
-            <Icon name="arrowRight" size={16} />
-          </ViewAllButton>
+          <Link to="/news-events" style={{ textDecoration: 'none' }}>
+            <ViewAllButton>
+              전체보기
+              <Icon name="arrowRight" size={16} />
+            </ViewAllButton>
+          </Link>
         </SectionHeader>
 
         <CardContainer>

--- a/src/components/pages/AnnouncementsPage/index.tsx
+++ b/src/components/pages/AnnouncementsPage/index.tsx
@@ -1,13 +1,180 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import MainLayout from '../../templates/MainLayout';
+import Icon from '../../atoms/Icon';
+
+// --- MOCK DATA ---
+const mockAnnouncements = [
+  {
+    id: 1,
+    title: '[JB-Bio] 2024년 바이오 스타트업 성장 지원 프로그램 참여기업 모집',
+    organization: '전북바이오융합산업진흥원',
+    deadline: '2024-08-20',
+    budget: '5,000만원',
+    status: 'urgent',
+    daysLeft: 5,
+    category: 'startup-support',
+  },
+  {
+    id: 2,
+    title: '글로벌 바이오 기술 이전 설명회 개최 안내',
+    organization: '한국생명공학연구원',
+    deadline: '2024-08-25',
+    budget: 'N/A',
+    status: 'active',
+    daysLeft: 10,
+    category: 'tech-transfer',
+  },
+  {
+    id: 3,
+    title: '2024년 3분기 연구장비 공동활용 지원사업 공고',
+    organization: '과학기술정보통신부',
+    deadline: '2024-09-10',
+    budget: '1억원',
+    status: 'active',
+    daysLeft: 26,
+    category: 'rnd-support',
+  },
+  // Add more mock data as needed
+];
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const PageHeader = styled.header`
+  margin-bottom: 2.5rem;
+  text-align: center;
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 0.5rem;
+`;
+
+const PageSubtitle = styled.p`
+  font-size: 1.125rem;
+  color: #4b5563;
+`;
+
+const ListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const ListItemLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+  display: block;
+`;
+
+const ListItemWrapper = styled.div`
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  background-color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const ItemHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+`;
+
+const StatusBadge = styled.span<{ status: 'active' | 'urgent' }>`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  background-color: ${props => props.status === 'active' ? '#10b981' : '#f59e0b'};
+  color: white;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+`;
+
+const DaysLeft = styled.div<{ days: number }>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: ${props => props.days <= 7 ? '#f59e0b' : '#4f46e5'};
+  font-size: 0.875rem;
+  font-weight: 700;
+`;
+
+const ItemTitle = styled.h4`
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 1rem 0;
+  line-height: 1.4;
+`;
+
+const ItemFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding-top: 1rem;
+  border-top: 1px solid #f3f4f6;
+`;
+
+const Organization = styled.span``;
+const Budget = styled.span`
+  font-weight: 600;
+  color: #111827;
+`;
+
+
+// --- COMPONENT ---
 
 const AnnouncementsPage = () => {
   return (
     <MainLayout>
-      <div style={{ padding: '2rem' }}>
-        <h1>JB 지원사업공고</h1>
-        <p>페이지가 준비중입니다.</p>
-      </div>
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>JB 지원사업공고</PageTitle>
+          <PageSubtitle>전북 바이오산업의 성장을 위한 다양한 지원사업을 확인하세요.</PageSubtitle>
+        </PageHeader>
+        <ListContainer>
+          {mockAnnouncements.map((announcement) => (
+            <ListItemLink key={announcement.id} to={`/support/${announcement.category}/${announcement.id}`}>
+              <ListItemWrapper>
+                <ItemHeader>
+                  <StatusBadge status={announcement.status}>
+                    {announcement.status === 'active' ? '진행중' : '마감임박'}
+                  </StatusBadge>
+                  <DaysLeft days={announcement.daysLeft}>
+                    <Icon name="clock" size={14} />
+                    D-{announcement.daysLeft}
+                  </DaysLeft>
+                </ItemHeader>
+                <ItemTitle>{announcement.title}</ItemTitle>
+                <ItemFooter>
+                  <Organization>{announcement.organization}</Organization>
+                  <Budget>{announcement.budget}</Budget>
+                </ItemFooter>
+              </ListItemWrapper>
+            </ListItemLink>
+          ))}
+        </ListContainer>
+      </PageWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
- Implements the `AnnouncementsPage` to display a list of announcements with links to the detail page.
- Updates the `ContentGrid` on the homepage to link to the announcements list and detail pages.
- Refactors `AnnouncementListItem` to use styled-components.