### PR TITLE
fix: Correct type for status prop in AnnouncementsPage

### DIFF
--- a/src/components/pages/AnnouncementsPage/index.tsx
+++ b/src/components/pages/AnnouncementsPage/index.tsx
@@ -4,8 +4,20 @@ import { Link } from 'react-router-dom';
 import MainLayout from '../../templates/MainLayout';
 import Icon from '../../atoms/Icon';
 
+// --- DATA MODELS ---
+interface Announcement {
+  id: number;
+  title: string;
+  organization: string;
+  deadline: string;
+  budget: string;
+  status: 'active' | 'urgent';
+  daysLeft: number;
+  category: string;
+}
+
 // --- MOCK DATA ---
-const mockAnnouncements = [
+const mockAnnouncements: Announcement[] = [
   {
     id: 1,
     title: '[JB-Bio] 2024년 바이오 스타트업 성장 지원 프로그램 참여기업 모집',


### PR DESCRIPTION
Resolves a TypeScript error where a generic string was passed to a component expecting a specific union type.

- Defines an `Announcement` interface to enforce the correct type for the `status` prop.
- Applies the new type to the mock data array.