### PR TITLE
fix(Button): Add disabled prop to Button atom

### DIFF
--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -6,11 +6,12 @@ interface ButtonProps {
   style?: React.CSSProperties;
   className?: string;
   key?: React.Key;
+  disabled?: boolean;
 }
 
-const Button: React.FC<ButtonProps> = ({ children, onClick, style, className, key }) => {
+const Button: React.FC<ButtonProps> = ({ children, onClick, style, className, key, disabled }) => {
   return (
-    <button key={key} onClick={onClick} style={style} className={className}>
+    <button key={key} onClick={onClick} style={style} className={className} disabled={disabled}>
       {children}
     </button>
   );


### PR DESCRIPTION
Updates the Button atom to accept a `disabled` prop and pass it to the underlying HTML element.

This resolves a TypeScript error in the Pagination component, which uses a styled version of the Button and needs to pass the `disabled` prop.