### PR TITLE
feat: Connect UI to Bio News pages

### DIFF
--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -211,7 +211,7 @@ const ContentGrid = () => {
       <Section>
         <SectionHeader>
           <SectionTitle>최신 뉴스</SectionTitle>
-          <Link to="/news-events" style={{ textDecoration: 'none' }}>
+          <Link to="/news/latest" style={{ textDecoration: 'none' }}>
             <ViewAllButton>
               전체보기
               <Icon name="arrowRight" size={16} />
@@ -221,14 +221,16 @@ const ContentGrid = () => {
 
         <CardContainer>
           {news.map((item) => (
-            <NewsCard key={item.id}>
-              <NewsCardHeader>
-                <NewsCardCategory>{item.category}</NewsCardCategory>
-                <NewsCardDate>{item.date}</NewsCardDate>
-              </NewsCardHeader>
-              <NewsCardTitle>{item.title}</NewsCardTitle>
-              <NewsCardSummary>{item.summary}</NewsCardSummary>
-            </NewsCard>
+            <Link key={item.id} to={`/news/latest/${item.id}`} style={{ textDecoration: 'none' }}>
+              <NewsCard>
+                <NewsCardHeader>
+                  <NewsCardCategory>{item.category}</NewsCardCategory>
+                  <NewsCardDate>{item.date}</NewsCardDate>
+                </NewsCardHeader>
+                <NewsCardTitle>{item.title}</NewsCardTitle>
+                <NewsCardSummary>{item.summary}</NewsCardSummary>
+              </NewsCard>
+            </Link>
           ))}
         </CardContainer>
       </Section>

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -198,7 +198,7 @@ const Header = () => {
     { text: 'JB BIO 클러스터', path: '/cluster' },
     { text: 'JB 지원사업공고', path: '/announcements' },
     { text: 'JB 창업보육센터', path: '/incubation' },
-    { text: '바이오 뉴스/행사', path: '/news-events' },
+    { text: '바이오 뉴스/행사', path: '/news' },
     { text: 'JB 기업정보', path: '/companies' },
     { text: 'JB 기술/특허', path: '/tech-patents' },
   ];


### PR DESCRIPTION
- Updates the main header navigation link for 'Bio News/Events' to point to `/news`.
- Updates the homepage 'Latest News' section to link to the news list and detail pages.