### PR TITLE
feat: Scaffold Incubation page with tabbed layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import NewsListPage from './components/pages/NewsListPage';
 import NewsDetailPage from './components/pages/NewsDetailPage';
 import EventsListPage from './components/pages/EventsListPage';
 import EventsDetailPage from './components/pages/EventsDetailPage';
+import TenantDetailPage from './components/pages/TenantDetailPage';
 
 function App() {
   return (
@@ -20,7 +21,10 @@ function App() {
       <Route path="/cluster" element={<ClusterPage />} />
       <Route path="/announcements" element={<AnnouncementsPage />} />
       <Route path="/support/:category/:announcementId" element={<AnnouncementDetailPage />} />
+
+      {/* Incubation Routes */}
       <Route path="/incubation" element={<IncubationPage />} />
+      <Route path="/incubation/tenants/:orgId" element={<TenantDetailPage />} />
 
       {/* News & Events Routes */}
       <Route path="/news" element={<NewsDashboardPage />} />

--- a/src/components/molecules/Tabs/index.tsx
+++ b/src/components/molecules/Tabs/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// --- STYLED COMPONENTS ---
+
+const TabsWrapper = styled.div`
+  border-bottom: 1px solid #d1d5db; /* gray-300 */
+  margin-bottom: 2rem;
+`;
+
+const TabList = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+const TabButton = styled.button<{ isActive: boolean }>`
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${props => (props.isActive ? '#4f46e5' : '#6b7280')};
+  border-bottom: 2px solid ${props => (props.isActive ? '#4f46e5' : 'transparent')};
+  margin-bottom: -1px; /* To align with the wrapper's border */
+  transition: color 0.2s, border-color 0.2s;
+
+  &:hover {
+    color: #4f46e5;
+  }
+`;
+
+// --- COMPONENT ---
+
+interface Tab {
+  id: string;
+  label: string;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  activeTab: string;
+  onTabClick: (tabId: string) => void;
+}
+
+const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, onTabClick }) => {
+  return (
+    <TabsWrapper>
+      <TabList>
+        {tabs.map(tab => (
+          <TabButton
+            key={tab.id}
+            isActive={tab.id === activeTab}
+            onClick={() => onTabClick(tab.id)}
+          >
+            {tab.label}
+          </TabButton>
+        ))}
+      </TabList>
+    </TabsWrapper>
+  );
+};
+
+export default Tabs;

--- a/src/components/organisms/IncubationTabs/ApplyView.tsx
+++ b/src/components/organisms/IncubationTabs/ApplyView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ApplyView = () => {
+  return (
+    <div>
+      <h2>Apply View</h2>
+      <p>Placeholder for the Application Procedures content.</p>
+    </div>
+  );
+};
+
+export default ApplyView;

--- a/src/components/organisms/IncubationTabs/DashboardView.tsx
+++ b/src/components/organisms/IncubationTabs/DashboardView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const DashboardView = () => {
+  return (
+    <div>
+      <h2>Dashboard View</h2>
+      <p>Placeholder for the Incubation Dashboard content.</p>
+    </div>
+  );
+};
+
+export default DashboardView;

--- a/src/components/organisms/IncubationTabs/TenantsView.tsx
+++ b/src/components/organisms/IncubationTabs/TenantsView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const TenantsView = () => {
+  return (
+    <div>
+      <h2>Tenants View</h2>
+      <p>Placeholder for the Tenants list content.</p>
+    </div>
+  );
+};
+
+export default TenantsView;

--- a/src/components/organisms/IncubationTabs/VacancyView.tsx
+++ b/src/components/organisms/IncubationTabs/VacancyView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const VacancyView = () => {
+  return (
+    <div>
+      <h2>Vacancy View</h2>
+      <p>Placeholder for the Vacancy list content.</p>
+    </div>
+  );
+};
+
+export default VacancyView;

--- a/src/components/pages/IncubationPage/index.tsx
+++ b/src/components/pages/IncubationPage/index.tsx
@@ -1,13 +1,72 @@
 import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
 import MainLayout from '../../templates/MainLayout';
+import Tabs from '../../molecules/Tabs';
+import DashboardView from '../../organisms/IncubationTabs/DashboardView';
+import TenantsView from '../../organisms/IncubationTabs/TenantsView';
+import VacancyView from '../../organisms/IncubationTabs/VacancyView';
+import ApplyView from '../../organisms/IncubationTabs/ApplyView';
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const PageHeader = styled.header`
+  margin-bottom: 2rem;
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+`;
+
+// --- COMPONENT ---
 
 const IncubationPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'dashboard';
+
+  const handleTabClick = (tabId: string) => {
+    setSearchParams({ tab: tabId });
+  };
+
+  const tabs = [
+    { id: 'dashboard', label: '대시보드' },
+    { id: 'tenants', label: '입주기관' },
+    { id: 'vacancy', label: '공실 현황' },
+    { id: 'apply', label: '절차/신청' },
+  ];
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case 'tenants':
+        return <TenantsView />;
+      case 'vacancy':
+        return <VacancyView />;
+      case 'apply':
+        return <ApplyView />;
+      case 'dashboard':
+      default:
+        return <DashboardView />;
+    }
+  };
+
   return (
     <MainLayout>
-      <div style={{ padding: '2rem' }}>
-        <h1>JB 창업보육센터 현황</h1>
-        <p>페이지가 준비중입니다.</p>
-      </div>
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>JB 창업보육센터</PageTitle>
+        </PageHeader>
+        <Tabs tabs={tabs} activeTab={activeTab} onTabClick={handleTabClick} />
+        <div>
+          {renderContent()}
+        </div>
+      </PageWrapper>
     </MainLayout>
   );
 };

--- a/src/components/pages/TenantDetailPage/index.tsx
+++ b/src/components/pages/TenantDetailPage/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import MainLayout from '../../templates/MainLayout';
+import { useParams } from 'react-router-dom';
+
+const TenantDetailPage = () => {
+  const { orgId } = useParams();
+  return (
+    <MainLayout>
+      <h1>Tenant Detail Page</h1>
+      <p>Details for Tenant ID: {orgId}</p>
+    </MainLayout>
+  );
+};
+
+export default TenantDetailPage;


### PR DESCRIPTION
This commit completes Phase 1 of the 'Incubation Center' feature.

- Adds new routes for the feature.
- Implements a tab-based navigation structure on the main `/incubation` page.
- Creates a new reusable `Tabs` component.
- Creates placeholder components for each tab view.