### PR TITLE
fix(Grid): Add explicit align-items: stretch

### DIFF
--- a/src/components/atoms/Grid/index.tsx
+++ b/src/components/atoms/Grid/index.tsx
@@ -9,6 +9,7 @@ interface GridProps {
 
 const Grid = styled.div<GridProps>`
   display: grid;
+  align-items: stretch;
   grid-template-columns: repeat(${props => props.cols || 4}, 1fr);
   gap: ${props => props.gap || '2rem'};
 


### PR DESCRIPTION
Adds `align-items: stretch;` to the `Grid` component to enforce consistent heights for all items in a grid row. This resolves a visual bug where cards with different amounts of content would cause inconsistent vertical spacing between rows.