### PR TITLE
feat: Implement Outcomes and Transfer pages

### DIFF
--- a/src/components/molecules/TransferCard/index.tsx
+++ b/src/components/molecules/TransferCard/index.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import Badge from '../../atoms/Badge';
+
+// --- STYLED COMPONENTS ---
+
+const CardLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  height: 100%;
+`;
+
+const CardWrapper = styled.div`
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+  transition: box-shadow 0.2s, border-color 0.2s;
+
+  &:hover {
+    border-color: #d1d5db;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+`;
+
+const Title = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.4;
+`;
+
+const Summary = styled.p`
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.5;
+  margin: 0;
+  flex-grow: 1;
+`;
+
+const Footer = styled.div`
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding-top: 0.75rem;
+  border-top: 1px solid #f3f4f6;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+// --- COMPONENT ---
+
+export interface TransferCardData {
+  id: string;
+  title: string;
+  summary: string;
+  ownerOrg: string;
+  status: 'open' | 'closing-soon' | 'closed';
+  deadline?: string;
+}
+
+interface TransferCardProps {
+  transfer: TransferCardData;
+}
+
+const getStatusBadge = (status: TransferCardData['status']) => {
+    switch(status) {
+        case 'open':
+            return <Badge backgroundColor="#dcfce7" color="#166534">모집중</Badge>;
+        case 'closing-soon':
+            return <Badge backgroundColor="#fef3c7" color="#92400e">마감임박</Badge>;
+        case 'closed':
+            return <Badge backgroundColor="#e5e7eb" color="#4b5563">마감</Badge>;
+    }
+}
+
+const TransferCard: React.FC<TransferCardProps> = ({ transfer }) => {
+  const dDay = transfer.deadline ? Math.ceil((new Date(transfer.deadline).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : null;
+
+  return (
+    <CardLink to={`/tech/transfer/${transfer.id}`}>
+      <CardWrapper>
+        <Header>
+            <Title>{transfer.title}</Title>
+            {getStatusBadge(transfer.status)}
+        </Header>
+        <Summary>{transfer.summary}</Summary>
+        <Footer>
+          <span>{transfer.ownerOrg}</span>
+          {dDay !== null && dDay >= 0 && <strong>D-{dDay}</strong>}
+        </Footer>
+      </CardWrapper>
+    </CardLink>
+  );
+};
+
+export default TransferCard;

--- a/src/components/pages/TechDetailPage/index.tsx
+++ b/src/components/pages/TechDetailPage/index.tsx
@@ -5,6 +5,7 @@ import MainLayout from '../../templates/MainLayout';
 import FileList, { FileData } from '../../molecules/FileList';
 import RelatedList, { RelatedItem } from '../../organisms/RelatedList';
 import Badge from '../../atoms/Badge';
+import InfoTable from '../../molecules/InfoTable';
 
 // --- MOCK DATA ---
 const mockOutcomeDetail = {
@@ -12,7 +13,7 @@ const mockOutcomeDetail = {
   title: '고효율 페로브스카이트 태양전지 안정성 향상 기술',
   orgName: '한국화학연구원',
   publishedAt: '2024-08-10',
-  viewCount: 2,580,
+  viewCount: 2580,
   fields: ['에너지', '소재', '페로브스카이트'],
   attachments: [
     { fileName: '연구성과 보고서.pdf', fileUrl: '#', fileSize: '3.5MB' },
@@ -21,7 +22,6 @@ const mockOutcomeDetail = {
   descriptionHTML: `
     <h2>연구 개요</h2>
     <p>본 연구는 차세대 태양전지로 각광받는 페로브스카이트(Perovskite) 태양전지의 상용화를 가로막는 가장 큰 문제점인 안정성 저하 문제를 해결하는 데 중점을 두었습니다. 새로운 유기-무기 하이브리드 소재를 개발하고, 박막 증착 공정을 최적화하여 수분과 열에 대한 저항성을 획기적으로 향상시켰습니다.</p>
-    <br/>
     <img src="https://picsum.photos/seed/tech1/800/450" alt="페로브스카이트 태양전지" style="max-width: 100%; border-radius: 8px; margin-bottom: 1rem;" />
     <h2>기대 효과</h2>
     <p>본 기술을 통해 페로브스카이트 태양전지의 수명을 2배 이상 늘리고, 생산 단가를 30% 절감할 수 있을 것으로 기대됩니다. 이는 국내 태양광 산업의 글로벌 경쟁력 강화에 크게 기여할 것입니다.</p>
@@ -30,6 +30,31 @@ const mockOutcomeDetail = {
     { id: 'transfer-1', title: '고효율 태양전지용 투명 전극 기술 이전', url: '/tech/transfer/transfer-1' },
     { id: 'patent-1', title: '페로브스카이트 안정화 첨가제 관련 특허', url: '/tech/patents/patent-1' },
   ]
+};
+
+const mockTransferDetail = {
+    id: 'transfer-1',
+    title: '고효율 태양전지용 투명 전극 기술',
+    ownerOrg: '한국화학연구원',
+    status: 'open',
+    deadline: '2024-10-31',
+    fields: ['에너지', '디스플레이', '소재'],
+    method: '실시권',
+    cost: '정액 기술료(5,000만원) + 경상 기술료(매출액의 2%)',
+    contactName: '박기술',
+    contactEmail: 'tech@krict.re.kr',
+    descriptionHTML: `
+        <h2>기술 개요</h2>
+        <p>본 기술은 ITO를 대체할 수 있는 유연 투명 전극 소재 기술로, 높은 광투과도와 전기 전도성을 동시에 만족시킵니다. 롤투롤 공정이 가능하여 대량생산에 유리합니다.</p>
+        <h2>적용 분야</h2>
+        <p>플렉서블 디스플레이, 스마트 윈도우, 박막형 태양전지 등 다양한 분야에 적용 가능합니다.</p>
+    `,
+    attachments: [
+        { fileName: '기술소개서(TLO).pdf', fileUrl: '#', fileSize: '2.1MB' },
+    ],
+    relatedItems: [
+        { id: 'outcome-1', title: '고효율 페로브스카이트 태양전지 안정성 향상 기술', url: '/tech/outcomes/outcome-1' },
+    ]
 };
 
 // --- STYLED COMPONENTS ---
@@ -106,19 +131,51 @@ const renderOutcomeDetail = () => (
         {mockOutcomeDetail.fields.map(tag => <Badge key={tag}>{tag}</Badge>)}
       </TagContainer>
     </ArticleHeader>
-
     <ArticleBody dangerouslySetInnerHTML={{ __html: mockOutcomeDetail.descriptionHTML }} />
-
     {mockOutcomeDetail.attachments && (
       <Section>
         <SectionTitle>첨부파일</SectionTitle>
         <FileList files={mockOutcomeDetail.attachments as FileData[]} />
       </Section>
     )}
-
     <RelatedList title="관련 항목" items={mockOutcomeDetail.relatedItems as RelatedItem[]} />
   </>
 );
+
+const renderTransferDetail = () => {
+    const transferInfo = {
+        '보유기관': mockTransferDetail.ownerOrg,
+        '이전 형태': mockTransferDetail.method,
+        '기술료': mockTransferDetail.cost,
+        '담당자': `${mockTransferDetail.contactName} (${mockTransferDetail.contactEmail})`,
+        '모집 마감': new Date(mockTransferDetail.deadline).toLocaleDateString(),
+    };
+    return (
+        <>
+            <ArticleHeader>
+                <Title>{mockTransferDetail.title}</Title>
+                <TagContainer>
+                    {mockTransferDetail.fields.map(tag => <Badge key={tag}>{tag}</Badge>)}
+                </TagContainer>
+            </ArticleHeader>
+            <Section>
+                <SectionTitle>기술 이전 조건</SectionTitle>
+                <InfoTable title="" data={transferInfo} />
+            </Section>
+            <Section>
+                <SectionTitle>기술 상세</SectionTitle>
+                <ArticleBody dangerouslySetInnerHTML={{ __html: mockTransferDetail.descriptionHTML }} />
+            </Section>
+            {mockTransferDetail.attachments && (
+                <Section>
+                    <SectionTitle>첨부파일</SectionTitle>
+                    <FileList files={mockTransferDetail.attachments as FileData[]} />
+                </Section>
+            )}
+            <RelatedList title="관련 항목" items={mockTransferDetail.relatedItems as RelatedItem[]} />
+        </>
+    );
+};
 
 
 // --- MAIN COMPONENT ---
@@ -130,7 +187,9 @@ const TechDetailPage = () => {
     switch (type) {
       case 'outcomes':
         return renderOutcomeDetail();
-      // TODO: Add cases for 'transfer', 'patents', 'collaboration'
+      case 'transfer':
+        return renderTransferDetail();
+      // TODO: Add cases for 'patents', 'collaboration'
       default:
         return <p>Unknown type: {type}</p>;
     }

--- a/src/components/pages/TechTransferPage/index.tsx
+++ b/src/components/pages/TechTransferPage/index.tsx
@@ -1,11 +1,91 @@
 import React from 'react';
+import styled from 'styled-components';
 import MainLayout from '../../templates/MainLayout';
+import SearchBar from '../../molecules/SearchBar';
+import FilterBar from '../../molecules/FilterBar';
+import Pagination from '../../molecules/Pagination';
+import Grid from '../../atoms/Grid';
+import TransferCard, { TransferCardData } from '../../molecules/TransferCard';
+
+// --- MOCK DATA ---
+const mockTransfers: TransferCardData[] = [
+  {
+    id: 'transfer-1',
+    title: '고효율 태양전지용 투명 전극 기술',
+    summary: '높은 광투과도와 전기 전도성을 동시에 만족시키는 신규 투명 전극 소재 및 공정 기술. 플렉서블 디스플레이 및 태양전지에 적용 가능.',
+    ownerOrg: '한국화학연구원',
+    status: 'open',
+    deadline: '2024-10-31',
+  },
+  {
+    id: 'transfer-2',
+    title: '미세먼지 제거용 광촉매 필터 기술',
+    summary: '가시광선에도 반응하여 유해물질과 미세먼지를 효과적으로 분해하는 고효율 광촉매 필터 제조 기술.',
+    ownerOrg: '한국에너지기술연구원',
+    status: 'closing-soon',
+    deadline: '2024-08-30',
+  },
+  {
+    id: 'transfer-3',
+    title: '퇴행성 뇌질환 치료용 펩타이드 후보물질',
+    summary: '알츠하이머, 파킨슨병 등 퇴행성 뇌질환의 진행을 억제하는 신규 펩타이드 후보물질. 전임상 완료.',
+    ownerOrg: 'KIST',
+    status: 'closed',
+  },
+  // Add more mock data as needed
+];
+
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const PageHeader = styled.header`
+  text-align: center;
+  margin-bottom: 2.5rem;
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+`;
+
+const ControlsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+// --- COMPONENT ---
 
 const TechTransferPage = () => {
   return (
     <MainLayout>
-      <h1>Technology Transfer</h1>
-      <p>Placeholder for the tech transfer list page.</p>
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>기술 이전</PageTitle>
+        </PageHeader>
+
+        <ControlsWrapper>
+          <FilterBar />
+          <SearchBar />
+        </ControlsWrapper>
+
+        <Grid cols={3} tabletCols={2} mobileCols={1} gap="1.5rem">
+          {mockTransfers.map((transfer) => (
+            <TransferCard key={transfer.id} transfer={transfer} />
+          ))}
+        </Grid>
+
+        <Pagination currentPage={1} totalPages={5} />
+      </PageWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
This completes Phases 3 and 4 of the 'Technology & Patents' feature.

- Builds out the `TechOutcomesPage` and `TechTransferPage` list views.
- Creates new `OutcomeCard` and `TransferCard` molecules.
- Updates the generic `TechDetailPage` to render views for both 'outcomes' and 'transfer' types.