### PR TITLE
feat: Implement Patents and Collaboration pages

### DIFF
--- a/src/components/molecules/CollaborationCard/index.tsx
+++ b/src/components/molecules/CollaborationCard/index.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import Badge from '../../atoms/Badge';
+
+// --- STYLED COMPONENTS ---
+
+const CardLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  height: 100%;
+`;
+
+const CardWrapper = styled.div`
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  transition: box-shadow 0.2s, border-color 0.2s;
+
+  &:hover {
+    border-color: #d1d5db;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const Title = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.4;
+`;
+
+const PartnerLogos = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+const Logo = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: contain;
+  background-color: white;
+  border: 1px solid #e5e7eb;
+`;
+
+const PartnerNames = styled.span`
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #4b5563;
+`;
+
+const Summary = styled.p`
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.5;
+  margin: 0;
+  flex-grow: 1;
+`;
+
+const Footer = styled.div`
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding-top: 1rem;
+  border-top: 1px solid #f3f4f6;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+// --- COMPONENT ---
+
+export interface CollaborationCardData {
+  id: string;
+  title: string;
+  summary: string;
+  partners: { name: string; logoUrl?: string }[];
+  year: number;
+  fields: string[];
+}
+
+interface CollaborationCardProps {
+  collaboration: CollaborationCardData;
+}
+
+const CollaborationCard: React.FC<CollaborationCardProps> = ({ collaboration }) => {
+  return (
+    <CardLink to={`/tech/collaboration/${collaboration.id}`}>
+      <CardWrapper>
+        <PartnerLogos>
+          {collaboration.partners.map((p, i) => (
+            <Logo key={i} src={p.logoUrl || 'https://via.placeholder.com/32'} alt={p.name} />
+          ))}
+          <PartnerNames>{collaboration.partners.map(p => p.name).join(' + ')}</PartnerNames>
+        </PartnerLogos>
+        <Title>{collaboration.title}</Title>
+        <Summary>{collaboration.summary}</Summary>
+        <Footer>
+          <div>{collaboration.fields.map(f => `#${f}`).join(' ')}</div>
+          <span>{collaboration.year}</span>
+        </Footer>
+      </CardWrapper>
+    </CardLink>
+  );
+};
+
+export default CollaborationCard;

--- a/src/components/pages/TechCollaborationPage/index.tsx
+++ b/src/components/pages/TechCollaborationPage/index.tsx
@@ -1,11 +1,90 @@
 import React from 'react';
+import styled from 'styled-components';
 import MainLayout from '../../templates/MainLayout';
+import SearchBar from '../../molecules/SearchBar';
+import FilterBar from '../../molecules/FilterBar';
+import Pagination from '../../molecules/Pagination';
+import Grid from '../../atoms/Grid';
+import CollaborationCard, { CollaborationCardData } from '../../molecules/CollaborationCard';
+
+// --- MOCK DATA ---
+const mockCollaborations: CollaborationCardData[] = [
+  {
+    id: 'collab-1',
+    title: '산학협력: AI 기반 암 진단 솔루션 개발',
+    summary: '전북대학교 컴퓨터공학부와 바이오젠 테라퓨틱스가 협력하여 딥러닝 기반의 암 조직 이미지 판독 정확도를 98%까지 향상시킨 사례.',
+    partners: [
+        { name: '전북대학교', logoUrl: 'https://picsum.photos/seed/jbnu/32' },
+        { name: '바이오젠', logoUrl: 'https://picsum.photos/seed/logo1/32' },
+    ],
+    year: 2023,
+    fields: ['AI', '진단', '산학협력'],
+  },
+  {
+    id: 'collab-2',
+    title: '기업-기업 공동연구: 차세대 백신 플랫폼 개발',
+    summary: 'SK바이오사이언스와 GC녹십자가 mRNA 백신 플랫폼 기술 국산화를 위해 R&D 컨소시엄을 구성하여 공동 연구를 진행한 성공 사례.',
+    partners: [
+        { name: 'SK바이오', logoUrl: 'https://picsum.photos/seed/skbio/32' },
+        { name: 'GC녹십자', logoUrl: 'https://picsum.photos/seed/gc/32' },
+    ],
+    year: 2024,
+    fields: ['백신', 'mRNA', '기업간협력'],
+  },
+  // Add more mock data as needed
+];
+
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const PageHeader = styled.header`
+  text-align: center;
+  margin-bottom: 2.5rem;
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+`;
+
+const ControlsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+// --- COMPONENT ---
 
 const TechCollaborationPage = () => {
   return (
     <MainLayout>
-      <h1>Technology Collaboration Cases</h1>
-      <p>Placeholder for the tech collaboration list page.</p>
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>기술 협력 사례</PageTitle>
+        </PageHeader>
+
+        <ControlsWrapper>
+          <FilterBar />
+          <SearchBar />
+        </ControlsWrapper>
+
+        <Grid cols={3} tabletCols={2} mobileCols={1} gap="1.5rem">
+          {mockCollaborations.map((collab) => (
+            <CollaborationCard key={collab.id} collaboration={collab} />
+          ))}
+        </Grid>
+
+        <Pagination currentPage={1} totalPages={2} />
+      </PageWrapper>
     </MainLayout>
   );
 };

--- a/src/components/pages/TechDetailPage/index.tsx
+++ b/src/components/pages/TechDetailPage/index.tsx
@@ -17,18 +17,13 @@ const mockOutcomeDetail = {
   fields: ['에너지', '소재', '페로브스카이트'],
   attachments: [
     { fileName: '연구성과 보고서.pdf', fileUrl: '#', fileSize: '3.5MB' },
-    { fileName: '기술소개자료.pptx', fileUrl: '#', fileSize: '10.2MB' },
   ],
   descriptionHTML: `
-    <h2>연구 개요</h2>
-    <p>본 연구는 차세대 태양전지로 각광받는 페로브스카이트(Perovskite) 태양전지의 상용화를 가로막는 가장 큰 문제점인 안정성 저하 문제를 해결하는 데 중점을 두었습니다. 새로운 유기-무기 하이브리드 소재를 개발하고, 박막 증착 공정을 최적화하여 수분과 열에 대한 저항성을 획기적으로 향상시켰습니다.</p>
+    <p>본 연구는 차세대 태양전지로 각광받는 페로브스카이트(Perovskite) 태양전지의 상용화를 가로막는 가장 큰 문제점인 안정성 저하 문제를 해결하는 데 중점을 두었습니다.</p>
     <img src="https://picsum.photos/seed/tech1/800/450" alt="페로브스카이트 태양전지" style="max-width: 100%; border-radius: 8px; margin-bottom: 1rem;" />
-    <h2>기대 효과</h2>
-    <p>본 기술을 통해 페로브스카이트 태양전지의 수명을 2배 이상 늘리고, 생산 단가를 30% 절감할 수 있을 것으로 기대됩니다. 이는 국내 태양광 산업의 글로벌 경쟁력 강화에 크게 기여할 것입니다.</p>
   `,
   relatedItems: [
     { id: 'transfer-1', title: '고효율 태양전지용 투명 전극 기술 이전', url: '/tech/transfer/transfer-1' },
-    { id: 'patent-1', title: '페로브스카이트 안정화 첨가제 관련 특허', url: '/tech/patents/patent-1' },
   ]
 };
 
@@ -36,85 +31,57 @@ const mockTransferDetail = {
     id: 'transfer-1',
     title: '고효율 태양전지용 투명 전극 기술',
     ownerOrg: '한국화학연구원',
-    status: 'open',
     deadline: '2024-10-31',
-    fields: ['에너지', '디스플레이', '소재'],
+    fields: ['에너지', '디스플레이'],
     method: '실시권',
     cost: '정액 기술료(5,000만원) + 경상 기술료(매출액의 2%)',
     contactName: '박기술',
     contactEmail: 'tech@krict.re.kr',
     descriptionHTML: `
         <h2>기술 개요</h2>
-        <p>본 기술은 ITO를 대체할 수 있는 유연 투명 전극 소재 기술로, 높은 광투과도와 전기 전도성을 동시에 만족시킵니다. 롤투롤 공정이 가능하여 대량생산에 유리합니다.</p>
-        <h2>적용 분야</h2>
-        <p>플렉서블 디스플레이, 스마트 윈도우, 박막형 태양전지 등 다양한 분야에 적용 가능합니다.</p>
+        <p>본 기술은 ITO를 대체할 수 있는 유연 투명 전극 소재 기술로, 높은 광투과도와 전기 전도성을 동시에 만족시킵니다.</p>
     `,
-    attachments: [
-        { fileName: '기술소개서(TLO).pdf', fileUrl: '#', fileSize: '2.1MB' },
-    ],
-    relatedItems: [
-        { id: 'outcome-1', title: '고효율 페로브스카이트 태양전지 안정성 향상 기술', url: '/tech/outcomes/outcome-1' },
-    ]
+    attachments: [ { fileName: '기술소개서(TLO).pdf', fileUrl: '#', fileSize: '2.1MB' } ],
+    relatedItems: [ { id: 'outcome-1', title: '고효율 페로브스카이트 태양전지 안정성 향상 기술', url: '/tech/outcomes/outcome-1' } ]
+};
+
+const mockPatentDetail = {
+    id: 'patent-1',
+    title: '페로브스카이트 안정화 첨가제',
+    number: '10-2023-0012345',
+    status: 'granted',
+    applicant: '한국화학연구원',
+    filedAt: '2023-01-15',
+    grantedAt: '2024-06-20',
+    ipcCodes: ['H01L 51/52', 'C07F 15/00'],
+    abstractHTML: '<p>본 발명은 페로브스카이트 태양전지의 안정성을 향상시키는 신규 유기 첨가제에 관한 것이다.</p>',
+    figureUrl: 'https://picsum.photos/seed/patent1/600/400',
+    sourceUrl: '#',
+};
+
+const mockCollaborationDetail = {
+    id: 'collab-1',
+    title: '산학협력: AI 기반 암 진단 솔루션 개발',
+    partners: [ { name: '전북대학교' }, { name: '바이오젠 테라퓨틱스' } ],
+    year: 2023,
+    fields: ['AI', '진단', '산학협력'],
+    descriptionHTML: `
+        <h2>성과</h2>
+        <p>딥러닝 모델을 개발하여 위암 조직 슬라이드 이미지 판독 정확도를 98.5%까지 달성하였으며, 이는 전문의 평균 정확도를 상회하는 수치이다.</p>
+    `,
+    relatedItems: [ { id: 'tenant-1', title: '바이오젠 테라퓨틱스 입주 정보', url: '/incubation/tenants/tenant-1' } ]
 };
 
 // --- STYLED COMPONENTS ---
 
-const PageWrapper = styled.div`
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 2rem;
-`;
-
-const ArticleHeader = styled.header`
-  margin-bottom: 2rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid #e5e7eb;
-`;
-
-const Title = styled.h1`
-  font-size: 2.25rem;
-  font-weight: 700;
-  line-height: 1.3;
-  margin-bottom: 1rem;
-`;
-
-const Metadata = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem 2rem;
-  font-size: 0.875rem;
-  color: #6b7280;
-  margin-bottom: 1rem;
-`;
-
-const TagContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-`;
-
-const ArticleBody = styled.div`
-  line-height: 1.7;
-  font-size: 1rem;
-  color: #374151;
-  margin: 2rem 0;
-
-  h2 { font-size: 1.75rem; font-weight: 600; margin: 2rem 0 1rem; }
-  p { margin-bottom: 1rem; }
-`;
-
-const Section = styled.section`
-  margin-top: 3rem;
-`;
-
-const SectionTitle = styled.h2`
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid #e5e7eb;
-`;
-
+const PageWrapper = styled.div` max-width: 900px; margin: 0 auto; padding: 2rem; `;
+const ArticleHeader = styled.header` margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid #e5e7eb; `;
+const Title = styled.h1` font-size: 2.25rem; font-weight: 700; line-height: 1.3; margin-bottom: 1rem; `;
+const Metadata = styled.div` display: flex; flex-wrap: wrap; gap: 1rem 2rem; font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem; `;
+const TagContainer = styled.div` display: flex; flex-wrap: wrap; gap: 0.5rem; `;
+const ArticleBody = styled.div` line-height: 1.7; font-size: 1rem; color: #374151; margin: 2rem 0; h2 { font-size: 1.75rem; font-weight: 600; margin: 2rem 0 1rem; } p { margin-bottom: 1rem; } `;
+const Section = styled.section` margin-top: 3rem; `;
+const SectionTitle = styled.h2` font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e5e7eb; `;
 
 // --- RENDER FUNCTIONS ---
 
@@ -177,6 +144,58 @@ const renderTransferDetail = () => {
     );
 };
 
+const renderPatentDetail = () => {
+    const patentInfo = {
+        '출원/등록번호': mockPatentDetail.number,
+        '상태': <Badge>{mockPatentDetail.status}</Badge>,
+        '출원인': mockPatentDetail.applicant,
+        '출원일': mockPatentDetail.filedAt,
+        '등록일': mockPatentDetail.grantedAt,
+        'IPC 분류': mockPatentDetail.ipcCodes.join(', '),
+    };
+    return (
+        <>
+            <ArticleHeader>
+                <Title>{mockPatentDetail.title}</Title>
+                <a href={mockPatentDetail.sourceUrl} target="_blank" rel="noopener noreferrer">원문 보기</a>
+            </ArticleHeader>
+            <Section>
+                <SectionTitle>특허 정보</SectionTitle>
+                <InfoTable title="" data={patentInfo} />
+            </Section>
+            <Section>
+                <SectionTitle>초록</SectionTitle>
+                <ArticleBody dangerouslySetInnerHTML={{ __html: mockPatentDetail.abstractHTML }} />
+                {mockPatentDetail.figureUrl && <img src={mockPatentDetail.figureUrl} alt="대표도면" style={{maxWidth: '100%', borderRadius: '8px'}} />}
+            </Section>
+        </>
+    );
+};
+
+const renderCollaborationDetail = () => {
+    const collabInfo = {
+        '참여기관': mockCollaborationDetail.partners.map(p => p.name).join(' + '),
+        '수행연도': mockCollaborationDetail.year,
+        '핵심분야': mockCollaborationDetail.fields.join(', '),
+    };
+    return (
+        <>
+            <ArticleHeader>
+                <Title>{mockCollaborationDetail.title}</Title>
+            </ArticleHeader>
+            <Section>
+                <SectionTitle>협력 개요</SectionTitle>
+                <InfoTable title="" data={collabInfo} />
+            </Section>
+            <Section>
+                <SectionTitle>상세 내용</SectionTitle>
+                <ArticleBody dangerouslySetInnerHTML={{ __html: mockCollaborationDetail.descriptionHTML }} />
+            </Section>
+            <RelatedList title="관련 항목" items={mockCollaborationDetail.relatedItems as RelatedItem[]} />
+        </>
+    );
+};
+
 
 // --- MAIN COMPONENT ---
 
@@ -189,7 +208,10 @@ const TechDetailPage = () => {
         return renderOutcomeDetail();
       case 'transfer':
         return renderTransferDetail();
-      // TODO: Add cases for 'patents', 'collaboration'
+      case 'patents':
+        return renderPatentDetail();
+      case 'collaboration':
+        return renderCollaborationDetail();
       default:
         return <p>Unknown type: {type}</p>;
     }

--- a/src/components/pages/TechPatentsPage/index.tsx
+++ b/src/components/pages/TechPatentsPage/index.tsx
@@ -1,13 +1,98 @@
 import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import MainLayout from '../../templates/MainLayout';
+import SearchBar from '../../molecules/SearchBar';
+import FilterBar from '../../molecules/FilterBar';
+import Pagination from '../../molecules/Pagination';
+import TableList from '../../molecules/TableList';
+import Badge from '../../atoms/Badge';
+
+// --- MOCK DATA ---
+const mockPatents = [
+  { id: 'patent-1', status: 'granted', title: '페로브스카이트 안정화 첨가제', number: '10-2023-0012345', filedAt: '2023-01-15', grantedAt: '2024-06-20', applicant: '한국화학연구원', isInternational: true },
+  { id: 'patent-2', status: 'published', title: 'AI 기반 진단 보조 시스템', number: '10-2023-0067890', filedAt: '2023-05-20', grantedAt: null, applicant: '메디퓨처', isInternational: false },
+  { id: 'patent-3', status: 'filed', title: '천연물 유래 항염증 소재', number: '10-2024-0001122', filedAt: '2024-01-10', grantedAt: null, applicant: '그린사이언스', isInternational: false },
+];
+
+const patentHeaders = ['상태', '발명의 명칭', '출원/등록번호', '출원일', '등록일', '출원인', '국제특허'];
+
+const getStatusBadge = (status: 'granted' | 'published' | 'filed') => {
+    switch(status) {
+        case 'granted': return <Badge backgroundColor="#dcfce7" color="#166534">등록</Badge>;
+        case 'published': return <Badge backgroundColor="#e0e7ff" color="#3730a3">공개</Badge>;
+        case 'filed': return <Badge backgroundColor="#dbeafe" color="#1e40af">출원</Badge>;
+    }
+};
+
+const patentRows = mockPatents.map(p => [
+    getStatusBadge(p.status as any),
+    p.title,
+    p.number,
+    p.filedAt,
+    p.grantedAt || '-',
+    p.applicant,
+    p.isInternational ? 'Y' : 'N'
+]);
+
+
+// --- STYLED COMPONENTS ---
+
+const PageWrapper = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const PageHeader = styled.header`
+  text-align: center;
+  margin-bottom: 2.5rem;
+`;
+
+const PageTitle = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+`;
+
+const ControlsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+// --- COMPONENT ---
 
 const TechPatentsPage = () => {
+  const navigate = useNavigate();
+
+  const handleRowClick = (rowIndex: number) => {
+    const patentId = mockPatents[rowIndex].id;
+    navigate(`/tech/patents/${patentId}`);
+  };
+
   return (
     <MainLayout>
-      <div style={{ padding: '2rem' }}>
-        <h1>JB 기술 및 특허</h1>
-        <p>페이지가 준비중입니다.</p>
-      </div>
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>특허 등록 현황</PageTitle>
+        </PageHeader>
+
+        <ControlsWrapper>
+          <FilterBar />
+          <SearchBar />
+        </ControlsWrapper>
+
+        <TableList
+            headers={patentHeaders}
+            rows={patentRows}
+            onRowClick={handleRowClick}
+        />
+
+        <Pagination currentPage={1} totalPages={4} />
+      </PageWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
This completes Phase 5 of the 'Technology & Patents' feature.

- Builds out the `TechPatentsPage` and `TechCollaborationPage` list views.
- Creates a new reusable `CollaborationCard` molecule.
- Updates the generic `TechDetailPage` to render views for both 'patents' and 'collaboration' types.