### PR TITLE
fix(TechPatentsPage): Fix rendering error by moving component creatio…

### DIFF
--- a/src/components/pages/TechPatentsPage/index.tsx
+++ b/src/components/pages/TechPatentsPage/index.tsx
@@ -25,17 +25,6 @@ const getStatusBadge = (status: 'granted' | 'published' | 'filed') => {
     }
 };
 
-const patentRows = mockPatents.map(p => [
-    getStatusBadge(p.status as any),
-    p.title,
-    p.number,
-    p.filedAt,
-    p.grantedAt || '-',
-    p.applicant,
-    p.isInternational ? 'Y' : 'N'
-]);
-
-
 // --- STYLED COMPONENTS ---
 
 const PageWrapper = styled.div`
@@ -67,6 +56,16 @@ const ControlsWrapper = styled.div`
 
 const TechPatentsPage = () => {
   const navigate = useNavigate();
+
+  const patentRows = mockPatents.map(p => [
+      getStatusBadge(p.status as any),
+      p.title,
+      p.number,
+      p.filedAt,
+      p.grantedAt || '-',
+      p.applicant,
+      p.isInternational ? 'Y' : 'N'
+  ]);
 
   const handleRowClick = (rowIndex: number) => {
     const patentId = mockPatents[rowIndex].id;


### PR DESCRIPTION
…n into render cycle

The `patentRows` constant, which contains React components (`<Badge>`), was being created at the module's top level. This can cause issues with libraries like styled-components, as the necessary theme context may not be available when the module is first evaluated.

By moving the `patentRows` creation inside the `TechPatentsPage` functional component, we ensure that the `<Badge>` components are created only during the React render cycle. This guarantees that they have access to the correct context and fixes the rendering error on the page.