### PR TITLE
fix: Resolve rendering and routing issue for Tech Patents page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
       <Route path="/tech" element={<TechDashboardPage />} />
       <Route path="/tech/outcomes" element={<TechOutcomesPage />} />
       <Route path="/tech/transfer" element={<TechTransferPage />} />
-      <Route path="/tech/patents" element={<TechPatentsPage />} />
+      <Route path="/tech-patents" element={<TechPatentsPage />} />
       <Route path="/tech/collaboration" element={<TechCollaborationPage />} />
       <Route path="/tech/:type/:id" element={<TechDetailPage />} />
 


### PR DESCRIPTION
This commit addresses two issues preventing the Tech Patents page from rendering correctly.

First, it fixes a styled-components rendering error by moving the `patentRows` constant creation from the module scope to inside the `TechPatentsPage` component. This ensures that React components within the array are created during the render cycle, with the proper context available.

Second, it corrects the route for the page in `App.tsx` from `/tech/patents` to `/tech-patents`. This aligns the route with the URL the user was trying to access, resolving a 'No routes matched location' error.