### PR TITLE
feat: Add backend endpoint for cluster dashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
 
 # --- API Routers ---
 # Routers for each domain will be included here to modularize the application.
-from .routers import announcement, company, infra, content, consultation, user, admin, service, stat
+from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster
 
 app.include_router(announcement.router)
 app.include_router(company.router)
@@ -29,6 +29,7 @@ app.include_router(user.router)
 app.include_router(admin.router)
 app.include_router(service.router)
 app.include_router(stat.router)
+app.include_router(cluster.router)
 # ...
 
 

--- a/backend/routers/cluster.py
+++ b/backend/routers/cluster.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter
+from typing import List, Dict, Any
+from ..db.mock_data import stats_db, companies_db, announcements_db
+from datetime import datetime
+
+router = APIRouter(
+    prefix="/cluster",
+    tags=["Cluster"],
+)
+
+@router.get("/dashboard", response_model=Dict[str, Any])
+def get_cluster_dashboard():
+    """
+    Get data for the cluster dashboard.
+    """
+    # 1. Prepare KPIs data
+    kpis = [
+        {"title": stat.label, "value": stat.value, "change": stat.change}
+        for stat in stats_db
+    ]
+
+    # 2. Prepare Latest Organizations data
+    # NOTE: The Company model doesn't have date/status, so we'll generate mock ones.
+    latest_orgs = [
+        {
+            "id": org.id,
+            "name": org.name,
+            "date": "2025-08-15", # Using a fixed date for consistency
+            "status": "NEW"
+        }
+        for org in companies_db[:4] # Take first 4
+    ]
+
+    # 3. Prepare Latest Policies data
+    # Sort announcements by date to get the latest ones
+    latest_policies_raw = sorted(announcements_db, key=lambda x: x.created_at, reverse=True)
+    latest_policies = [
+        {
+            "id": policy.id,
+            "name": policy.title,
+            "date": policy.created_at.strftime('%Y-%m-%d'),
+            "status": "NEW" if (datetime.now() - policy.created_at).days < 30 else "UPDATED"
+        }
+        for policy in latest_policies_raw[:4] # Take first 4
+    ]
+
+    return {
+        "kpis": kpis,
+        "latestOrgs": latest_orgs,
+        "latestPolicies": latest_policies,
+    }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,31 +1,5 @@
 import { http, HttpResponse } from 'msw';
 
-const dashboardHandler = http.get('/api/cluster/dashboard', () => {
-  return HttpResponse.json({
-    kpis: [
-      { title: '클러스터 내 기관', value: '132', change: '+2' },
-      { title: '보유 인프라', value: '45', change: '+5' },
-      { title: '활성 지원정책', value: '28', change: '-1' },
-      { title: '이번 달 신규 기관', value: '6', change: '' },
-    ],
-    latestOrgs: [
-      { id: 'org-1', name: '메디퓨처', date: '2024-08-15', status: 'NEW' },
-      { id: 'org-2', name: '그린사이언스', date: '2024-08-14', status: 'NEW' },
-      { id: 'org-3', name: '한국화학연구원', date: '2024-08-12', status: 'UPDATED' },
-      { id: 'org-4', name: '바이오톡스텍', date: '2024-08-11', status: 'NEW' },
-      { id: 'org-5', name: '셀트리온', date: '2024-08-10', status: 'UPDATED' },
-      { id: 'org-6', name: '삼성바이오로직스', date: '2024-08-09', status: 'NEW' },
-    ],
-    latestPolicies: [
-      { id: 'pol-1', name: '2024년 바이오 스타트업 지원사업', date: '2024-08-10', status: 'NEW' },
-      { id: 'pol-2', name: '연구장비 공동활용 지원', date: '2024-08-09', status: 'UPDATED' },
-      { id: 'pol-3', name: '기술이전 R&BD 사업화 지원', date: '2024-08-05', status: 'UPDATED' },
-      { id: 'pol-4', name: '바이오 분야 전문인력 양성사업', date: '2024-08-02', status: 'NEW' },
-      { id: 'pol-5', name: '임상시험 연계 지원 프로그램', date: '2024-07-28', status: 'UPDATED' },
-      { id: 'pol-6', name: '해외 바이오 클러스터 교류 지원', date: '2024-07-25', status: 'NEW' },
-    ],
-  });
-});
 
 // --- MOCK DATA ---
 
@@ -88,7 +62,6 @@ const organizationDetailHandler = http.get('/api/cluster/organizations/:id', ({ 
 });
 
 export const handlers = [
-  dashboardHandler,
   organizationsHandler,
   organizationDetailHandler,
 ];


### PR DESCRIPTION
This commit introduces a new backend endpoint at `/api/cluster/dashboard` to serve data for the cluster dashboard page.

Previously, the frontend was relying on a mock service worker handler for this data, which was causing errors. This commit removes the mock handler and replaces it with a call to the new backend endpoint.

The new endpoint provides mock data for KPIs, latest organizations, and latest policies, resolving the errors on the cluster page.