### PR TITLE
fix: Disable mock service worker in development

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,12 +17,12 @@ async function enableMocking() {
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-enableMocking().then(() => {
-  root.render(
-    <React.StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </React.StrictMode>
-  );
-});
+// enableMocking().then(() => {
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+// });


### PR DESCRIPTION
The frontend was not communicating with the backend because the mock service worker was intercepting all API requests in the development environment. This change disables the mock service worker by commenting out its initialization in `src/index.tsx`. This will allow the frontend to make real API calls to the backend.