### PR TITLE
This change introduces the ability to configure the API endpoint usin…

### DIFF
--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -29,7 +29,9 @@ const useDashboardData = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const response = await fetch('/api/cluster/dashboard');
+        const baseUrl = process.env.REACT_APP_API_BASE_URL || '';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${baseUrl}${apiPrefix}/cluster/dashboard`);
         if (!response.ok) {
           throw new Error('네트워크 응답이 올바르지 않습니다.');
         }

--- a/src/hooks/useOrganizationById.ts
+++ b/src/hooks/useOrganizationById.ts
@@ -15,7 +15,9 @@ const useOrganizationById = (id: string | null) => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`/api/cluster/organizations/${id}`);
+        const baseUrl = process.env.REACT_APP_API_BASE_URL || '';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${baseUrl}${apiPrefix}/cluster/organizations/${id}`);
         if (!response.ok) {
           throw new Error('네트워크 응답이 올바르지 않습니다.');
         }

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -40,7 +40,9 @@ const useOrganizations = () => {
         if (orgType) params.append('type', orgType);
         if (keyword) params.append('query', keyword);
 
-        const response = await fetch(`/api/cluster/organizations?${params.toString()}`);
+        const baseUrl = process.env.REACT_APP_API_BASE_URL || '';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${baseUrl}${apiPrefix}/cluster/organizations?${params.toString()}`);
         if (!response.ok) {
           throw new Error('네트워크 응답이 올바르지 않습니다.');
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,12 +17,12 @@ async function enableMocking() {
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-// enableMocking().then(() => {
-root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
-);
-// });
+enableMocking().then(() => {
+  root.render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </React.StrictMode>
+  );
+});


### PR DESCRIPTION
…g environment variables (`REACT_APP_API_BASE_URL` and `REACT_APP_API_PREFIX`).

Previously, the frontend was using hardcoded relative URLs for API calls, which were intercepted by a mock service worker in development. This prevented it from communicating with a real backend.

This commit resolves the issue by:
- Adding a `.env` file to specify the backend URL.
- Modifying the API calling hooks (`useOrganizations`, `useOrganizationById`, `useDashboardData`) to construct the full API URL from the new environment variables.

This provides a flexible way to switch between mock and real backend services without changing the source code.