### PR TITLE
feat: Add /api prefix to all API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,16 +20,16 @@ app.add_middleware(
 # Routers for each domain will be included here to modularize the application.
 from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster
 
-app.include_router(announcement.router)
-app.include_router(company.router)
-app.include_router(infra.router)
-app.include_router(content.router)
-app.include_router(consultation.router)
-app.include_router(user.router)
-app.include_router(admin.router)
-app.include_router(service.router)
-app.include_router(stat.router)
-app.include_router(cluster.router)
+app.include_router(announcement.router, prefix="/api")
+app.include_router(company.router, prefix="/api")
+app.include_router(infra.router, prefix="/api")
+app.include_router(content.router, prefix="/api")
+app.include_router(consultation.router, prefix="/api")
+app.include_router(user.router, prefix="/api")
+app.include_router(admin.router, prefix="/api")
+app.include_router(service.router, prefix="/api")
+app.include_router(stat.router, prefix="/api")
+app.include_router(cluster.router, prefix="/api")
 # ...
 
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -6,7 +6,7 @@ from ..db.mock_data import announcements_db
 from .user import get_current_user, User
 
 router = APIRouter(
-    prefix="/api/admin",
+    prefix="/admin",
     tags=["Admin"],
     dependencies=[Depends(get_current_user)] # Protect all admin routes
 )

--- a/backend/routers/announcement.py
+++ b/backend/routers/announcement.py
@@ -5,7 +5,7 @@ from ..models.announcement import Announcement
 from ..db.mock_data import announcements_db
 
 router = APIRouter(
-    prefix="/api/announcements",
+    prefix="/announcements",
     tags=["Announcements"],
 )
 

--- a/backend/routers/cluster.py
+++ b/backend/routers/cluster.py
@@ -4,7 +4,7 @@ from ..db.mock_data import stats_db, companies_db, announcements_db
 from datetime import datetime
 
 router = APIRouter(
-    prefix="/api/cluster",
+    prefix="/cluster",
     tags=["Cluster"],
 )
 

--- a/backend/routers/company.py
+++ b/backend/routers/company.py
@@ -5,7 +5,7 @@ from ..models.company import Company
 from ..db.mock_data import companies_db
 
 router = APIRouter(
-    prefix="/api/companies",
+    prefix="/companies",
     tags=["Companies & Institutions"],
 )
 

--- a/backend/routers/consultation.py
+++ b/backend/routers/consultation.py
@@ -6,7 +6,7 @@ from ..models.consultation import Consultation, ConsultationCreate
 from ..db.mock_data import consultations_db
 
 router = APIRouter(
-    prefix="/api/consultations",
+    prefix="/consultations",
     tags=["Consultations"],
 )
 

--- a/backend/routers/content.py
+++ b/backend/routers/content.py
@@ -5,7 +5,6 @@ from ..models.content import News, Tech
 from ..db.mock_data import news_db, techs_db
 
 router = APIRouter(
-    prefix="/api",
     tags=["Content"]
 )
 

--- a/backend/routers/infra.py
+++ b/backend/routers/infra.py
@@ -5,7 +5,7 @@ from ..models.infra import Infra
 from ..db.mock_data import infra_db
 
 router = APIRouter(
-    prefix="/api/infra",
+    prefix="/infra",
     tags=["Infrastructure"],
 )
 

--- a/backend/routers/service.py
+++ b/backend/routers/service.py
@@ -4,9 +4,7 @@ from typing import List
 from ..models.service import Service
 from ..db.mock_data import services_db
 
-router = APIRouter(
-    prefix="/api"
-)
+router = APIRouter()
 
 @router.get("/services", response_model=List[Service], tags=["Services"])
 def get_services_list():

--- a/backend/routers/stat.py
+++ b/backend/routers/stat.py
@@ -4,9 +4,7 @@ from typing import List
 from ..models.stat import Stat
 from ..db.mock_data import stats_db
 
-router = APIRouter(
-    prefix="/api"
-)
+router = APIRouter()
 
 @router.get("/stats", response_model=List[Stat], tags=["Stats"])
 def get_stats_list():

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -6,7 +6,6 @@ from ..models.user import User, Token
 from ..db.mock_data import users_db
 
 router = APIRouter(
-    prefix="/api",
     tags=["Users"]
 )
 

--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -148,8 +148,8 @@ const ContentGrid = () => {
     const fetchData = async () => {
       try {
         const [announcementsResponse, newsResponse] = await Promise.all([
-          fetch(`${process.env.REACT_APP_API_URL}/announcements?limit=3`),
-          fetch(`${process.env.REACT_APP_API_URL}/news?limit=3`)
+          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=3`),
+          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=3`)
         ]);
 
         if (!announcementsResponse.ok || !newsResponse.ok) {

--- a/src/components/organisms/ServicesSection/index.tsx
+++ b/src/components/organisms/ServicesSection/index.tsx
@@ -84,7 +84,7 @@ const ServicesSection = () => {
   useEffect(() => {
     const fetchServices = async () => {
       try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/services`);
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/services`);
         if (!response.ok) {
           throw new Error('Network response was not ok');
         }

--- a/src/components/organisms/StatsSection/index.tsx
+++ b/src/components/organisms/StatsSection/index.tsx
@@ -27,7 +27,7 @@ const StatsSection = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/stats`);
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/stats`);
         if (!response.ok) {
           throw new Error('Network response was not ok');
         }


### PR DESCRIPTION
Refactored the backend to apply a consistent /api prefix to all API endpoints by centralizing the prefix logic in main.py.

Updated the corresponding frontend components to call the new /api-prefixed endpoints, fixing the 404 errors for /stats, /services, /announcements, and /news.