### PR TITLE
feat: 3가지 새로운 홈페이지 디자인 시안 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/pages/HomePage';
+import HomePageSample1 from './components/pages/HomePageSample1';
+import HomePageSample2 from './components/pages/HomePageSample2';
+import HomePageSample3 from './components/pages/HomePageSample3';
 import AnnouncementsPage from './components/pages/AnnouncementsPage';
 import IncubationPage from './components/pages/IncubationPage';
 import CompaniesPage from './components/pages/CompaniesPage';
@@ -28,6 +31,9 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/home-sample1" element={<HomePageSample1 />} />
+      <Route path="/home-sample2" element={<HomePageSample2 />} />
+      <Route path="/home-sample3" element={<HomePageSample3 />} />
       <Route path="/cluster" element={<ClusterDashboardPage />} />
       <Route path="/cluster/hub" element={<ClusterHubPage />} />
       <Route path="/cluster/organizations" element={<ClusterOrgsPage />} />

--- a/src/components/organisms/ContentGridSample1/index.tsx
+++ b/src/components/organisms/ContentGridSample1/index.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+// Simplified data models for this component
+interface Announcement {
+  id: number;
+  title: string;
+  organization: string;
+  daysLeft: number;
+}
+
+interface News {
+  id: number;
+  title: string;
+  category: string;
+  date: string;
+}
+
+const ContentGridSample1 = () => {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [news, setNews] = useState<News[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [announcementsResponse, newsResponse] = await Promise.all([
+          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=3`),
+          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=3`)
+        ]);
+
+        if (!announcementsResponse.ok || !newsResponse.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const announcementsData = await announcementsResponse.json();
+        const newsData = await newsResponse.json();
+
+        setAnnouncements(announcementsData.map(item => ({
+          id: item.id,
+          title: item.title,
+          organization: item.author,
+          daysLeft: 30, // Mock data
+        })));
+        setNews(newsData.map(item => ({
+          id: item.id,
+          title: item.title,
+          category: item.category === 'news' ? '산업뉴스' : '공지',
+          date: new Date(item.created_at).toLocaleDateString(),
+        })));
+      } catch (error) {
+        console.error('Failed to fetch content grid data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const listItemStyle: React.CSSProperties = {
+    padding: '1rem 0',
+    borderBottom: '1px solid #e9ecef',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '1rem',
+    color: '#212529',
+    fontWeight: '500',
+    textDecoration: 'none',
+  };
+
+  const metaStyle: React.CSSProperties = {
+    fontSize: '0.875rem',
+    color: '#6c757d',
+    textAlign: 'right',
+  };
+
+  return (
+    <section style={{ maxWidth: '1200px', margin: '0 auto 4rem auto', padding: '0 1rem' }}>
+      <Grid $cols={2} $tabletCols={1} $mobileCols={1} $gap="3rem">
+        {/* 최신 공고 */}
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', margin: 0 }}>최신 공고</h2>
+            <Link to="/announcements" style={{ textDecoration: 'none', color: '#495057', fontSize: '0.9rem' }}>
+              전체보기 <Icon name="arrowRight" size={14} />
+            </Link>
+          </div>
+          <div>
+            {announcements.map((item, index) => (
+              <Link to={`/support/all/${item.id}`} key={index} style={{ textDecoration: 'none' }}>
+                <div style={listItemStyle}>
+                  <span style={titleStyle}>{item.title}</span>
+                  <div style={metaStyle}>
+                    {item.organization}<br/>
+                    D-{item.daysLeft}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* 최신 뉴스 */}
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', margin: 0 }}>최신 뉴스</h2>
+            <Link to="/news/latest" style={{ textDecoration: 'none', color: '#495057', fontSize: '0.9rem' }}>
+              전체보기 <Icon name="arrowRight" size={14} />
+            </Link>
+          </div>
+          <div>
+            {news.map((item, index) => (
+              <Link to={`/news/latest/${item.id}`} key={index} style={{ textDecoration: 'none' }}>
+                <div style={listItemStyle}>
+                  <div>
+                    <span style={{...titleStyle, display: 'block', marginBottom: '0.25rem'}}>{item.title}</span>
+                    <span style={{...metaStyle, fontSize: '0.8rem', textAlign: 'left'}}>{item.category}</span>
+                  </div>
+                  <span style={metaStyle}>{item.date}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </Grid>
+    </section>
+  );
+};
+
+export default ContentGridSample1;

--- a/src/components/organisms/ContentGridSample2/index.tsx
+++ b/src/components/organisms/ContentGridSample2/index.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+import Button from '../../atoms/Button';
+
+interface Announcement {
+  id: number;
+  title: string;
+  organization: string;
+  status: 'active' | 'urgent';
+}
+
+interface News {
+  id: number;
+  title: string;
+  category: string;
+  date: string;
+}
+
+const ContentGridSample2 = () => {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [news, setNews] = useState<News[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [announcementsResponse, newsResponse] = await Promise.all([
+          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=4`),
+          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=4`)
+        ]);
+
+        if (!announcementsResponse.ok || !newsResponse.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const announcementsData = await announcementsResponse.json();
+        const newsData = await newsResponse.json();
+
+        setAnnouncements(announcementsData.map((item, index) => ({
+          id: item.id,
+          title: item.title,
+          organization: item.author,
+          status: index === 0 ? 'urgent' : 'active', // Mock status
+        })));
+        setNews(newsData.map(item => ({
+          id: item.id,
+          title: item.title,
+          category: item.category === 'news' ? '산업뉴스' : '공지',
+          date: new Date(item.created_at).toLocaleDateString(),
+        })));
+      } catch (error) {
+        console.error('Failed to fetch content grid data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const cardStyle: React.CSSProperties = {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '20px',
+    padding: '2rem',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '1.5rem',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '1.75rem',
+    fontWeight: 'bold',
+    margin: 0,
+  };
+
+  const itemStyle: React.CSSProperties = {
+    backgroundColor: '#ffffff',
+    borderRadius: '12px',
+    padding: '1rem 1.25rem',
+    marginBottom: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    textDecoration: 'none',
+    color: '#111827',
+    transition: 'transform 0.2s, box-shadow 0.2s',
+  };
+
+  return (
+    <section style={{ marginBottom: '4rem', backgroundColor: '#eef2ff', padding: '4rem 0' }}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1rem' }}>
+        <Grid $cols={2} $tabletCols={1} $mobileCols={1} $gap="2rem">
+          {/* 최신 공고 */}
+          <div style={cardStyle}>
+            <div style={headerStyle}>
+              <h2 style={titleStyle}>최신 공고</h2>
+              <Link to="/announcements">
+                <Button $variant="primary" $size="sm">전체보기</Button>
+              </Link>
+            </div>
+            <div style={{flexGrow: 1}}>
+              {announcements.map((item) => (
+                <Link to={`/support/all/${item.id}`} key={item.id} style={{...itemStyle, borderLeft: `4px solid ${item.status === 'urgent' ? '#ef4444' : '#3b82f6'}`}}>
+                    <div>
+                      <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{item.title}</div>
+                      <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>{item.organization}</div>
+                    </div>
+                    <Icon name="arrowRight" size={20} color="#9ca3af" />
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* 최신 뉴스 */}
+          <div style={cardStyle}>
+            <div style={headerStyle}>
+              <h2 style={titleStyle}>최신 뉴스</h2>
+              <Link to="/news/latest">
+                <Button $variant="primary" $size="sm">전체보기</Button>
+              </Link>
+            </div>
+            <div style={{flexGrow: 1}}>
+              {news.map((item) => (
+                <Link to={`/news/latest/${item.id}`} key={item.id} style={itemStyle}>
+                  <div>
+                    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem'}}>
+                      <span style={{backgroundColor: '#e0e7ff', color: '#4338ca', padding: '0.2rem 0.6rem', borderRadius: '20px', fontSize: '0.75rem', fontWeight: '600'}}>{item.category}</span>
+                      <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>{item.date}</div>
+                    </div>
+                    <div style={{ fontWeight: 'bold' }}>{item.title}</div>
+                  </div>
+                  <Icon name="arrowRight" size={20} color="#9ca3af" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </Grid>
+      </div>
+    </section>
+  );
+};
+
+export default ContentGridSample2;

--- a/src/components/organisms/ContentGridSample3/index.tsx
+++ b/src/components/organisms/ContentGridSample3/index.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Announcement {
+  id: number;
+  title: string;
+  organization: string;
+  deadline: string;
+}
+
+interface News {
+  id: number;
+  title: string;
+  category: string;
+  date: string;
+}
+
+const ContentGridSample3 = () => {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [news, setNews] = useState<News[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [announcementsResponse, newsResponse] = await Promise.all([
+          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=5`),
+          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=5`)
+        ]);
+
+        if (!announcementsResponse.ok || !newsResponse.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const announcementsData = await announcementsResponse.json();
+        const newsData = await newsResponse.json();
+
+        setAnnouncements(announcementsData.map(item => ({
+          id: item.id,
+          title: item.title,
+          organization: item.author,
+          deadline: new Date(new Date(item.created_at).getTime() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString(),
+        })));
+        setNews(newsData.map(item => ({
+          id: item.id,
+          title: item.title,
+          category: item.category === 'news' ? '산업뉴스' : '공지',
+          date: new Date(item.created_at).toLocaleDateString(),
+        })));
+      } catch (error) {
+        console.error('Failed to fetch content grid data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const sectionStyle: React.CSSProperties = {
+    padding: '2rem',
+    backgroundColor: '#f8f9fa',
+    borderRadius: '16px',
+    border: '1px solid #dee2e6',
+    height: '100%',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '1.5rem',
+    paddingBottom: '1rem',
+    borderBottom: '1px solid #dee2e6'
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '1.5rem',
+    fontWeight: 'bold',
+    color: '#1d3557',
+    margin: 0,
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '0.75rem 0',
+    borderBottom: '1px solid #e9ecef',
+    textDecoration: 'none',
+    color: 'inherit',
+  };
+
+  return (
+    <section style={{ marginBottom: '4rem', maxWidth: '1200px', margin: '0 auto 4rem auto', padding: '0 1rem' }}>
+      <Grid $cols={2} $tabletCols={1} $mobileCols={1} $gap="2rem">
+        {/* 최신 공고 */}
+        <div style={sectionStyle}>
+          <div style={headerStyle}>
+            <h2 style={titleStyle}>최신 공고</h2>
+            <Link to="/announcements" style={{ textDecoration: 'none', color: '#1d3557', fontWeight: 500 }}>
+              전체보기 <Icon name="arrowRight" size={16} />
+            </Link>
+          </div>
+          <div>
+            {announcements.map((item) => (
+              <Link to={`/support/all/${item.id}`} key={item.id} style={itemStyle}>
+                <span style={{ fontWeight: 500, color: '#212529' }}>{item.title}</span>
+                <span style={{ fontSize: '0.875rem', color: '#6c757d' }}>{item.deadline}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* 최신 뉴스 */}
+        <div style={sectionStyle}>
+          <div style={headerStyle}>
+            <h2 style={titleStyle}>최신 뉴스</h2>
+            <Link to="/news/latest" style={{ textDecoration: 'none', color: '#1d3557', fontWeight: 500 }}>
+              전체보기 <Icon name="arrowRight" size={16} />
+            </Link>
+          </div>
+          <div>
+            {news.map((item) => (
+               <Link to={`/news/latest/${item.id}`} key={item.id} style={itemStyle}>
+                <span style={{ fontWeight: 500, color: '#212529' }}>{item.title}</span>
+                <span style={{ fontSize: '0.875rem', color: '#6c757d' }}>{item.date}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </Grid>
+    </section>
+  );
+};
+
+export default ContentGridSample3;

--- a/src/components/organisms/HeroSectionSample1/index.tsx
+++ b/src/components/organisms/HeroSectionSample1/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import SearchBar from '../../molecules/SearchBar';
+
+const HeroSectionSample1 = () => {
+  return (
+    <section style={{
+      background: '#f8f9fa', // 아주 연한 회색 배경
+      borderRadius: '24px',
+      padding: `${DESIGN_SYSTEM.spacing[24]} ${DESIGN_SYSTEM.spacing[12]}`, // 세로 여백 증가
+      color: '#212529', // 어두운 텍스트 색상
+      textAlign: 'center',
+      marginBottom: DESIGN_SYSTEM.spacing[16],
+    } as React.CSSProperties}>
+      <h1 style={{
+        fontSize: DESIGN_SYSTEM.typography.fontSize['5xl'][0], // 폰트 크기 약간 줄임
+        fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold, // 폰트 두께 감소
+        margin: `0 0 ${DESIGN_SYSTEM.spacing[4]} 0`,
+        lineHeight: '1.2',
+        letterSpacing: '-0.02em'
+      } as React.CSSProperties}>
+        JBSQUARE.
+      </h1>
+      <p style={{
+        fontSize: DESIGN_SYSTEM.typography.fontSize.lg[0], // 폰트 크기 약간 줄임
+        margin: `0 0 ${DESIGN_SYSTEM.spacing[10]} 0`,
+        opacity: 0.8,
+        maxWidth: '680px',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        lineHeight: '1.7'
+      } as React.CSSProperties}>
+        전북의 미래를 함께 만드는 혁신 공간.
+        <br />
+        핵심 정보와 기회를 간결하게 전달합니다.
+      </p>
+      <SearchBar />
+    </section>
+  );
+};
+
+export default HeroSectionSample1;

--- a/src/components/organisms/HeroSectionSample2/index.tsx
+++ b/src/components/organisms/HeroSectionSample2/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import SearchBar from '../../molecules/SearchBar';
+
+const HeroSectionSample2 = () => {
+  return (
+    <section style={{
+      // 강렬한 보라색-파란색 계열 그라디언트
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      borderRadius: '24px',
+      padding: `${DESIGN_SYSTEM.spacing[20]} ${DESIGN_SYSTEM.spacing[12]}`,
+      color: 'white',
+      textAlign: 'center',
+      marginBottom: DESIGN_SYSTEM.spacing[16],
+      position: 'relative',
+      overflow: 'hidden'
+    } as React.CSSProperties}>
+      {/* 추상적인 배경 패턴 */}
+      <div style={{
+        position: 'absolute',
+        top: 0, left: 0, right: 0, bottom: 0,
+        backgroundImage: 'url("https://www.transparenttextures.com/patterns/cubes.png")',
+        opacity: 0.05,
+        backgroundSize: 'auto',
+      }} />
+
+      <div style={{ position: 'relative', zIndex: 1 } as React.CSSProperties}>
+        <h1 style={{
+          fontSize: DESIGN_SYSTEM.typography.fontSize['7xl'][0], // 더 큰 폰트 사이즈
+          fontWeight: DESIGN_SYSTEM.typography.fontWeight.black, // 가장 두꺼운 폰트
+          margin: `0 0 ${DESIGN_SYSTEM.spacing[6]} 0`,
+          lineHeight: '1.1',
+          letterSpacing: '-0.02em',
+          textShadow: '0 4px 15px rgba(0,0,0,0.2)' // 텍스트 그림자 추가
+        } as React.CSSProperties}>
+          INNOVATE. CONNECT. GROW.
+        </h1>
+        <p style={{
+          fontSize: DESIGN_SYSTEM.typography.fontSize.xl[0],
+          margin: `0 0 ${DESIGN_SYSTEM.spacing[12]} 0`,
+          opacity: 0.95,
+          maxWidth: '720px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          lineHeight: '1.6',
+          fontWeight: DESIGN_SYSTEM.typography.fontWeight.medium,
+        } as React.CSSProperties}>
+          전북의 미래를 여는 혁신 허브, JB SQUARE에서<br/>
+          당신의 가능성을 폭발시키세요.
+        </p>
+        <SearchBar />
+      </div>
+    </section>
+  );
+};
+
+export default HeroSectionSample2;

--- a/src/components/organisms/HeroSectionSample3/index.tsx
+++ b/src/components/organisms/HeroSectionSample3/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import SearchBar from '../../molecules/SearchBar';
+
+const HeroSectionSample3 = () => {
+  return (
+    <section style={{
+      background: '#ffffff',
+      border: '1px solid #dee2e6',
+      borderRadius: '16px',
+      padding: `${DESIGN_SYSTEM.spacing[16]} ${DESIGN_SYSTEM.spacing[12]}`,
+      color: '#000000', // 검은색 텍스트
+      textAlign: 'center',
+      marginBottom: DESIGN_SYSTEM.spacing[16],
+    } as React.CSSProperties}>
+      <h1 style={{
+        fontSize: DESIGN_SYSTEM.typography.fontSize['6xl'][0],
+        fontWeight: DESIGN_SYSTEM.typography.fontWeight.extrabold,
+        margin: `0 0 ${DESIGN_SYSTEM.spacing[4]} 0`,
+        lineHeight: '1.2',
+        letterSpacing: '-0.025em',
+        color: '#1d3557' // 전문적인 네이비 블루 색상
+      } as React.CSSProperties}>
+        데이터로 증명하는 혁신
+      </h1>
+      <p style={{
+        fontSize: DESIGN_SYSTEM.typography.fontSize.lg[0],
+        margin: `0 auto ${DESIGN_SYSTEM.spacing[10]} auto`,
+        opacity: 0.9,
+        maxWidth: '760px',
+        lineHeight: '1.7',
+        color: '#495057' // 차분한 회색 텍스트
+      } as React.CSSProperties}>
+        JB SQUARE는 데이터 기반의 인사이트를 통해 기업의 성장을 지원합니다.
+        <br />
+        정확한 정보와 통계로 최적의 비즈니스 결정을 내리세요.
+      </p>
+      <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+        <SearchBar />
+      </div>
+    </section>
+  );
+};
+
+export default HeroSectionSample3;

--- a/src/components/organisms/ServicesSectionSample1/index.tsx
+++ b/src/components/organisms/ServicesSectionSample1/index.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Service {
+  title: string;
+  description: string;
+  icon: string;
+  gradient: string; // We won't use this, but it's in the data
+}
+
+const ServicesSectionSample1 = () => {
+  const [services, setServices] = useState<Service[]>([]);
+
+  useEffect(() => {
+    const fetchServices = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/services`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setServices(data);
+      } catch (error) {
+        console.error('Failed to fetch services:', error);
+      }
+    };
+
+    fetchServices();
+  }, []);
+
+  return (
+    <section style={{ marginBottom: '4rem', backgroundColor: '#f8f9fa', padding: '4rem 0' }}>
+      <h2 style={{
+        fontSize: '1.75rem',
+        fontWeight: 'bold',
+        color: '#212529',
+        margin: '0 0 2.5rem 0',
+        textAlign: 'center',
+        letterSpacing: '-0.025em'
+      }}>
+        핵심 서비스
+      </h2>
+      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1rem' }}>
+        <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+          {services.map((item, index) => (
+            <div key={index} style={{
+              background: '#ffffff',
+              borderRadius: '16px',
+              padding: '2rem',
+              textAlign: 'center',
+              border: '1px solid #e9ecef',
+              transition: 'border-color 0.2s ease-in-out, transform 0.2s ease-in-out',
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.borderColor = '#adb5bd';
+              e.currentTarget.style.transform = 'translateY(-3px)';
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.borderColor = '#e9ecef';
+              e.currentTarget.style.transform = 'translateY(0)';
+            }}
+            >
+              <div style={{
+                marginBottom: '1.25rem',
+              }}>
+                <Icon name={item.icon} size={32} color="#495057" />
+              </div>
+              <h3 style={{
+                fontSize: '1.125rem',
+                fontWeight: 'bold',
+                color: '#212529',
+                margin: '0 0 0.75rem 0',
+              }}>{item.title}</h3>
+              <p style={{
+                fontSize: '0.9rem',
+                color: '#6c757d',
+                margin: 0,
+                lineHeight: 1.6,
+              }}>{item.description}</p>
+            </div>
+          ))}
+        </Grid>
+      </div>
+    </section>
+  );
+};
+
+export default ServicesSectionSample1;

--- a/src/components/organisms/ServicesSectionSample2/index.tsx
+++ b/src/components/organisms/ServicesSectionSample2/index.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Service {
+  title: string;
+  description: string;
+  icon: string;
+  gradient: string;
+}
+
+const ServicesSectionSample2 = () => {
+  const [services, setServices] = useState<Service[]>([]);
+
+  useEffect(() => {
+    const fetchServices = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/services`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setServices(data);
+      } catch (error) {
+        console.error('Failed to fetch services:', error);
+      }
+    };
+
+    fetchServices();
+  }, []);
+
+  return (
+    <section style={{ marginBottom: '4rem' }}>
+      <h2 style={{
+        fontSize: '2.5rem',
+        fontWeight: 'bold',
+        color: '#111827',
+        margin: '0 0 3rem 0',
+        textAlign: 'center',
+        letterSpacing: '-0.025em',
+      }}>
+        Our Services
+      </h2>
+      <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+        {services.map((item, index) => (
+          <div key={index} style={{
+            background: item.gradient,
+            borderRadius: '24px',
+            padding: '2.5rem 2rem',
+            cursor: 'pointer',
+            position: 'relative',
+            color: 'white',
+            transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+            transformStyle: 'preserve-3d',
+          } as React.CSSProperties}
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            const rotateX = (y / rect.height - 0.5) * -15;
+            const rotateY = (x / rect.width - 0.5) * 15;
+            e.currentTarget.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(1.05, 1.05, 1.05)`;
+            e.currentTarget.style.boxShadow = '0 30px 40px -15px rgba(0, 0, 0, 0.3)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = 'perspective(1000px) rotateX(0) rotateY(0) scale3d(1, 1, 1)';
+            e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(0, 0, 0, 0.1)';
+          }}
+          >
+            <div style={{
+                width: '72px',
+                height: '72px',
+                backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                borderRadius: '20px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginBottom: '1.5rem',
+              }}>
+              <Icon name={item.icon} size={40} color="white" />
+            </div>
+            <h3 style={{
+              fontSize: '1.5rem',
+              fontWeight: 'bold',
+              margin: '0 0 0.75rem 0',
+            }}>{item.title}</h3>
+            <p style={{
+              fontSize: '1rem',
+              margin: 0,
+              lineHeight: 1.6,
+              opacity: 0.9,
+            }}>{item.description}</p>
+          </div>
+        ))}
+      </Grid>
+    </section>
+  );
+};
+
+export default ServicesSectionSample2;

--- a/src/components/organisms/ServicesSectionSample3/index.tsx
+++ b/src/components/organisms/ServicesSectionSample3/index.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Service {
+  title: string;
+  description: string;
+  icon: string;
+  gradient: string; // Not used, but in the data model
+}
+
+const ServicesSectionSample3 = () => {
+  const [services, setServices] = useState<Service[]>([]);
+
+  useEffect(() => {
+    const fetchServices = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/services`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setServices(data);
+      } catch (error) {
+        console.error('Failed to fetch services:', error);
+      }
+    };
+
+    fetchServices();
+  }, []);
+
+  const sectionStyle: React.CSSProperties = {
+    marginBottom: '4rem',
+    padding: '0 1rem'
+  };
+
+  const titleStyle: React.CSSProperties = {
+    textAlign: 'center',
+    fontSize: '1.75rem',
+    fontWeight: 'bold',
+    color: '#1d3557',
+    marginBottom: '2.5rem'
+  };
+
+  const cardStyle: React.CSSProperties = {
+    background: '#ffffff',
+    borderRadius: '16px',
+    padding: '2rem',
+    border: '1px solid #dee2e6',
+    textAlign: 'left',
+    height: '100%',
+    transition: 'border-color 0.2s, box-shadow 0.2s',
+  };
+
+  const iconContainerStyle: React.CSSProperties = {
+    width: '56px',
+    height: '56px',
+    borderRadius: '12px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#eef2ff', // Light blue background
+    marginBottom: '1.5rem',
+  };
+
+  return (
+    <section style={sectionStyle}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
+        <h2 style={titleStyle}>핵심 서비스</h2>
+        <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+          {services.map((item, index) => (
+            <div key={index} style={cardStyle}
+              onMouseOver={(e) => {
+                e.currentTarget.style.borderColor = '#457b9d';
+                e.currentTarget.style.boxShadow = '0 4px 12px rgba(0,0,0,0.05)';
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.borderColor = '#dee2e6';
+                e.currentTarget.style.boxShadow = 'none';
+              }}>
+              <div style={iconContainerStyle}>
+                <Icon name={item.icon} size={28} color="#1d3557" />
+              </div>
+              <h3 style={{
+                fontSize: '1.25rem',
+                fontWeight: 'bold',
+                color: '#1d3557',
+                margin: '0 0 0.75rem 0',
+              }}>{item.title}</h3>
+              <p style={{
+                fontSize: '0.9rem',
+                color: '#495057',
+                margin: 0,
+                lineHeight: 1.6,
+              }}>{item.description}</p>
+            </div>
+          ))}
+        </Grid>
+      </div>
+    </section>
+  );
+};
+
+export default ServicesSectionSample3;

--- a/src/components/organisms/StatsSectionSample1/index.tsx
+++ b/src/components/organisms/StatsSectionSample1/index.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import StatCard from '../../molecules/StatCard';
+import Grid from '../../atoms/Grid';
+
+interface Stat {
+  label: string;
+  value: string;
+  change: string;
+  icon: string;
+  color: string;
+}
+
+const StatsSectionSample1 = () => {
+  const [stats, setStats] = useState<Stat[]>([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/stats`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        // For the minimalist design, we can simplify the data or presentation
+        const simplifiedData = data.map(stat => ({
+          ...stat,
+          color: '#495057', // Use a neutral color
+        }));
+        setStats(simplifiedData);
+      } catch (error) {
+        console.error('Failed to fetch stats:', error);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <section style={{ marginBottom: '4rem', padding: '2rem 0' }}>
+      <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+        {stats.map((stat, index) => (
+          <div key={index} style={{
+            padding: '1.5rem',
+            border: '1px solid #e9ecef',
+            borderRadius: '12px',
+            textAlign: 'center',
+            backgroundColor: '#fff',
+          }}>
+            <h3 style={{ fontSize: '1rem', color: '#6c757d', marginBottom: '0.5rem', fontWeight: 'normal' }}>{stat.label}</h3>
+            <p style={{ fontSize: '2rem', fontWeight: 'bold', color: '#212529', margin: '0' }}>{stat.value}</p>
+            <p style={{ fontSize: '0.9rem', color: stat.change.startsWith('+') ? '#28a745' : '#dc3545', margin: '0.25rem 0 0 0' }}>{stat.change}</p>
+          </div>
+        ))}
+      </Grid>
+    </section>
+  );
+};
+
+export default StatsSectionSample1;

--- a/src/components/organisms/StatsSectionSample2/index.tsx
+++ b/src/components/organisms/StatsSectionSample2/index.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import Grid from '../../atoms/Grid';
+import Icon from '../../atoms/Icon'; // Assuming Icon component can be used
+
+interface Stat {
+  label: string;
+  value: string;
+  change: string;
+  icon: string;
+  color: string; // The API provides a color, which we can use
+}
+
+const StatsSectionSample2 = () => {
+  const [stats, setStats] = useState<Stat[]>([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/stats`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setStats(data);
+      } catch (error) {
+        console.error('Failed to fetch stats:', error);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <section style={{ marginBottom: '4rem' }}>
+      <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+        {stats.map((stat, index) => (
+          <div key={index} style={{
+            background: stat.color,
+            color: 'white',
+            borderRadius: '20px',
+            padding: '2rem',
+            textAlign: 'left',
+            transition: 'transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
+            cursor: 'pointer',
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.transform = 'scale(1.05)';
+            e.currentTarget.style.boxShadow = '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)';
+          }}
+          onMouseOut={(e) => {
+            e.currentTarget.style.transform = 'scale(1)';
+            e.currentTarget.style.boxShadow = 'none';
+          }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+              <h3 style={{ fontSize: '1rem', fontWeight: 'bold', margin: 0, opacity: 0.9 }}>{stat.label}</h3>
+              <Icon name={stat.icon} size={24} color="white" />
+            </div>
+            <p style={{ fontSize: '2.5rem', fontWeight: 'bold', margin: '0 0 0.5rem 0' }}>{stat.value}</p>
+            <p style={{ fontSize: '0.9rem', margin: 0, opacity: 0.9 }}>{stat.change} vs last month</p>
+          </div>
+        ))}
+      </Grid>
+    </section>
+  );
+};
+
+export default StatsSectionSample2;

--- a/src/components/organisms/StatsSectionSample3/index.tsx
+++ b/src/components/organisms/StatsSectionSample3/index.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import Grid from '../../atoms/Grid';
+import Icon from '../../atoms/Icon';
+
+interface Stat {
+  label: string;
+  value: string;
+  change: string;
+  icon: string;
+  color: string;
+}
+
+const StatsSectionSample3 = () => {
+  const [stats, setStats] = useState<Stat[]>([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/stats`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setStats(data);
+      } catch (error) {
+        console.error('Failed to fetch stats:', error);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  const containerStyle: React.CSSProperties = {
+    backgroundColor: '#f8f9fa',
+    padding: '3rem 2rem',
+    borderRadius: '16px',
+    marginBottom: '4rem',
+    border: '1px solid #dee2e6'
+  };
+
+  const titleStyle: React.CSSProperties = {
+    textAlign: 'center',
+    fontSize: '1.75rem',
+    fontWeight: 'bold',
+    color: '#1d3557',
+    marginBottom: '2.5rem'
+  };
+
+  const statItemStyle: React.CSSProperties = {
+    textAlign: 'center',
+    padding: '0 1rem',
+    borderRight: '1px solid #dee2e6',
+  };
+
+  const lastStatItemStyle = {...statItemStyle, borderRight: 'none'};
+
+  return (
+    <section style={containerStyle}>
+      <h2 style={titleStyle}>주요 현황</h2>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        {stats.map((stat, index) => (
+          <div key={index} style={index === stats.length - 1 ? lastStatItemStyle : statItemStyle}>
+            <p style={{ fontSize: '0.9rem', color: '#6c757d', marginBottom: '0.75rem', textTransform: 'uppercase' }}>{stat.label}</p>
+            <p style={{ fontSize: '2.25rem', fontWeight: 'bold', color: '#1d3557', margin: '0 0 0.5rem 0' }}>{stat.value}</p>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.25rem', color: stat.change.startsWith('+') ? '#2a9d8f' : '#e76f51' }}>
+              <Icon name={stat.change.startsWith('+') ? "arrowUp" : "arrowDown"} size={14} />
+              <span style={{ fontSize: '0.9rem', fontWeight: '500' }}>{stat.change}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default StatsSectionSample3;

--- a/src/components/pages/HomePageSample1/index.tsx
+++ b/src/components/pages/HomePageSample1/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import MainLayout from '../../templates/MainLayout';
+import HeroSectionSample1 from '../../organisms/HeroSectionSample1';
+import StatsSectionSample1 from '../../organisms/StatsSectionSample1';
+import ServicesSectionSample1 from '../../organisms/ServicesSectionSample1';
+import ContentGridSample1 from '../../organisms/ContentGridSample1';
+
+/**
+ * ## UI-01-01: Home Page Sample 1 (Elegant Minimalism)
+ * ### Atomic Structure
+ * - Template: MainLayout
+ * - Organism: HeroSectionSample1
+ * - Organism: StatsSectionSample1
+ * - Organism: ServicesSectionSample1
+ * - Organism: ContentGridSample1
+ *
+ * @returns {JSX.Element}
+ */
+const HomePageSample1 = () => {
+  return (
+    <MainLayout>
+      <HeroSectionSample1 />
+      <StatsSectionSample1 />
+      <ServicesSectionSample1 />
+      <ContentGridSample1 />
+    </MainLayout>
+  );
+};
+
+export default HomePageSample1;

--- a/src/components/pages/HomePageSample2/index.tsx
+++ b/src/components/pages/HomePageSample2/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import MainLayout from '../../templates/MainLayout';
+import HeroSectionSample2 from '../../organisms/HeroSectionSample2';
+import StatsSectionSample2 from '../../organisms/StatsSectionSample2';
+import ServicesSectionSample2 from '../../organisms/ServicesSectionSample2';
+import ContentGridSample2 from '../../organisms/ContentGridSample2';
+
+/**
+ * ## UI-01-01: Home Page Sample 2 (Vibrant & Dynamic)
+ * ### Atomic Structure
+ * - Template: MainLayout
+ * - Organism: HeroSectionSample2
+ * - Organism: StatsSectionSample2
+ * - Organism: ServicesSectionSample2
+ * - Organism: ContentGridSample2
+ *
+ * @returns {JSX.Element}
+ */
+const HomePageSample2 = () => {
+  return (
+    <MainLayout>
+      <HeroSectionSample2 />
+      <StatsSectionSample2 />
+      <ServicesSectionSample2 />
+      <ContentGridSample2 />
+    </MainLayout>
+  );
+};
+
+export default HomePageSample2;

--- a/src/components/pages/HomePageSample3/index.tsx
+++ b/src/components/pages/HomePageSample3/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import MainLayout from '../../templates/MainLayout';
+import HeroSectionSample3 from '../../organisms/HeroSectionSample3';
+import StatsSectionSample3 from '../../organisms/StatsSectionSample3';
+import ServicesSectionSample3 from '../../organisms/ServicesSectionSample3';
+import ContentGridSample3 from '../../organisms/ContentGridSample3';
+
+/**
+ * ## UI-01-01: Home Page Sample 3 (Data-Driven Professionalism)
+ * ### Atomic Structure
+ * - Template: MainLayout
+ * - Organism: HeroSectionSample3
+ * - Organism: StatsSectionSample3
+ * - Organism: ServicesSectionSample3
+ * - Organism: ContentGridSample3
+ *
+ * @returns {JSX.Element}
+ */
+const HomePageSample3 = () => {
+  return (
+    <MainLayout>
+      <HeroSectionSample3 />
+      <StatsSectionSample3 />
+      <ServicesSectionSample3 />
+      <ContentGridSample3 />
+    </MainLayout>
+  );
+};
+
+export default HomePageSample3;


### PR DESCRIPTION
사용자의 요청에 따라 세 가지 새로운 홈페이지 디자인 시안을 추가합니다.

- `/home-sample1`: Elegant Minimalism
- `/home-sample2`: Vibrant & Dynamic
- `/home-sample3`: Data-Driven Professionalism

각 시안은 새로운 페이지 컴포넌트와 하위 컴포넌트로 구성되며,
`App.tsx`에 해당 경로가 추가되었습니다.

이를 통해 사용자는 세 가지 디자인을 직접 비교하고 검토할 수 있습니다.