### PR TITLE
fix: 시안 페이지의 검색창 중앙 정렬

### DIFF
--- a/src/components/organisms/HeroSectionSample1/index.tsx
+++ b/src/components/organisms/HeroSectionSample1/index.tsx
@@ -34,7 +34,9 @@ const HeroSectionSample1 = () => {
         <br />
         핵심 정보와 기회를 간결하게 전달합니다.
       </p>
-      <SearchBar />
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <SearchBar />
+      </div>
     </section>
   );
 };

--- a/src/components/organisms/HeroSectionSample2/index.tsx
+++ b/src/components/organisms/HeroSectionSample2/index.tsx
@@ -48,7 +48,9 @@ const HeroSectionSample2 = () => {
           전북의 미래를 여는 혁신 허브, JB SQUARE에서<br/>
           당신의 가능성을 폭발시키세요.
         </p>
-        <SearchBar />
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <SearchBar />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
사용자 피드백을 반영하여 `home-sample1`과 `home-sample2` 페이지의 Hero 영역에 있는 검색창이 중앙에 오도록 수정합니다.

`SearchBar` 컴포넌트를 `div`로 감싸고 flexbox를 사용하여 중앙 정렬을 적용했습니다.