### PR TITLE
feat: 4번째 홈페이지 디자인 시안 추가 (Futuristic Glassmorphism)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import HomePage from './components/pages/HomePage';
 import HomePageSample1 from './components/pages/HomePageSample1';
 import HomePageSample2 from './components/pages/HomePageSample2';
 import HomePageSample3 from './components/pages/HomePageSample3';
+import HomePageSample4 from './components/pages/HomePageSample4';
 import AnnouncementsPage from './components/pages/AnnouncementsPage';
 import IncubationPage from './components/pages/IncubationPage';
 import CompaniesPage from './components/pages/CompaniesPage';
@@ -34,6 +35,7 @@ function App() {
       <Route path="/home-sample1" element={<HomePageSample1 />} />
       <Route path="/home-sample2" element={<HomePageSample2 />} />
       <Route path="/home-sample3" element={<HomePageSample3 />} />
+      <Route path="/home-sample4" element={<HomePageSample4 />} />
       <Route path="/cluster" element={<ClusterDashboardPage />} />
       <Route path="/cluster/hub" element={<ClusterHubPage />} />
       <Route path="/cluster/organizations" element={<ClusterOrgsPage />} />

--- a/src/components/organisms/ContentGridSample4/index.tsx
+++ b/src/components/organisms/ContentGridSample4/index.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Announcement {
+  id: number;
+  title: string;
+}
+
+interface News {
+  id: number;
+  title: string;
+  category: string;
+}
+
+const ContentGridSample4 = () => {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [news, setNews] = useState<News[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [announcementsResponse, newsResponse] = await Promise.all([
+          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=5`),
+          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=5`)
+        ]);
+
+        if (!announcementsResponse.ok || !newsResponse.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const announcementsData = await announcementsResponse.json();
+        const newsData = await newsResponse.json();
+
+        setAnnouncements(announcementsData);
+        setNews(newsData);
+      } catch (error) {
+        console.error('Failed to fetch content grid data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const panelStyle: React.CSSProperties = {
+    background: 'rgba(0, 0, 0, 0.25)',
+    backdropFilter: 'blur(15px)',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    borderRadius: '24px',
+    padding: '2rem',
+    color: 'white',
+    height: '100%',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '1.5rem',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '1.75rem',
+    fontWeight: 'bold',
+    margin: 0,
+    textShadow: '0 0 5px rgba(255, 255, 255, 0.2)',
+  };
+
+  const listItemStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '1rem',
+    borderRadius: '12px',
+    textDecoration: 'none',
+    color: 'rgba(255, 255, 255, 0.85)',
+    transition: 'background-color 0.2s, color 0.2s',
+  };
+
+  return (
+    <section style={{ marginBottom: '4rem', maxWidth: '1200px', margin: '0 auto', padding: '0 1rem' }}>
+      <Grid $cols={2} $tabletCols={1} $mobileCols={1} $gap="2rem">
+        <div style={panelStyle}>
+          <div style={headerStyle}>
+            <h2 style={titleStyle}>Latest Announcements</h2>
+            <Link to="/announcements" style={{color: '#90d8ff', textDecoration: 'none', fontWeight: 'bold'}}>
+              View All
+            </Link>
+          </div>
+          <div>
+            {announcements.map((item) => (
+              <Link to={`/support/all/${item.id}`} key={item.id} style={listItemStyle}
+                onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'; e.currentTarget.style.color = '#ffffff'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'rgba(255, 255, 255, 0.85)'; }}
+              >
+                <span>{item.title}</span>
+                <Icon name="arrowRight" size={16} />
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div style={panelStyle}>
+          <div style={headerStyle}>
+            <h2 style={titleStyle}>Latest News</h2>
+            <Link to="/news/latest" style={{color: '#90d8ff', textDecoration: 'none', fontWeight: 'bold'}}>
+              View All
+            </Link>
+          </div>
+          <div>
+            {news.map((item) => (
+              <Link to={`/news/latest/${item.id}`} key={item.id} style={listItemStyle}
+                onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'; e.currentTarget.style.color = '#ffffff'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'rgba(255, 255, 255, 0.85)'; }}
+              >
+                <span>{item.title}</span>
+                <span style={{
+                  backgroundColor: 'rgba(255,255,255,0.15)',
+                  padding: '0.2rem 0.6rem',
+                  borderRadius: '20px',
+                  fontSize: '0.75rem',
+                  opacity: 0.8
+                }}>{item.category}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </Grid>
+    </section>
+  );
+};
+
+export default ContentGridSample4;

--- a/src/components/organisms/HeroSectionSample4/index.tsx
+++ b/src/components/organisms/HeroSectionSample4/index.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import SearchBar from '../../molecules/SearchBar'; // We can reuse the search bar
+
+const HeroSectionSample4 = () => {
+  const sectionStyle: React.CSSProperties = {
+    background: 'rgba(255, 255, 255, 0.1)',
+    backdropFilter: 'blur(20px)',
+    border: '1px solid rgba(255, 255, 255, 0.2)',
+    borderRadius: '32px',
+    padding: `${DESIGN_SYSTEM.spacing[20]} ${DESIGN_SYSTEM.spacing[12]}`,
+    color: 'white',
+    textAlign: 'center',
+    marginBottom: DESIGN_SYSTEM.spacing[16],
+    position: 'relative',
+    overflow: 'hidden',
+    boxShadow: '0 8px 32px 0 rgba(0, 0, 0, 0.1)'
+  };
+
+  const glowTextStyle: React.CSSProperties = {
+    textShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 12px rgba(255, 255, 255, 0.3)'
+  };
+
+  return (
+    <section style={sectionStyle}>
+      {/* Animated gradient blobs for background effect */}
+      <div style={{
+        position: 'absolute', top: '-50%', left: '-50%', width: '200%', height: '200%',
+        background: 'radial-gradient(circle, rgba(100, 100, 255, 0.3) 0%, rgba(255,255,255,0) 40%), radial-gradient(circle, rgba(255, 100, 100, 0.3) 50%, rgba(255,255,255,0) 80%)',
+        animation: 'rotate 20s linear infinite'
+      }} />
+      <style>{`
+        @keyframes rotate {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+      `}</style>
+
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        <h1 style={{
+          fontSize: DESIGN_SYSTEM.typography.fontSize['7xl'][0],
+          fontWeight: DESIGN_SYSTEM.typography.fontWeight.bold,
+          margin: `0 0 ${DESIGN_SYSTEM.spacing[6]} 0`,
+          lineHeight: '1.1',
+          letterSpacing: '0.02em',
+          ...glowTextStyle
+        }}>
+          FUTURE IS NOW
+        </h1>
+        <p style={{
+          fontSize: DESIGN_SYSTEM.typography.fontSize.xl[0],
+          margin: `0 0 ${DESIGN_SYSTEM.spacing[12]} 0`,
+          opacity: 0.9,
+          maxWidth: '720px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          lineHeight: '1.6',
+        }}>
+          JB SQUARE에서 펼쳐지는 혁신의 내일.
+          <br/>
+          가장 진보된 기술과 아이디어를 만나보세요.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          {/* We might need a custom SearchBar for this theme, but for now, we reuse */}
+          <SearchBar />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSectionSample4;

--- a/src/components/organisms/ServicesSectionSample4/index.tsx
+++ b/src/components/organisms/ServicesSectionSample4/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+import Icon from '../../atoms/Icon';
+import Grid from '../../atoms/Grid';
+
+interface Service {
+  title: string;
+  description: string;
+  icon: string;
+  gradient: string;
+}
+
+const ServicesSectionSample4 = () => {
+  const [services, setServices] = useState<Service[]>([]);
+
+  useEffect(() => {
+    const fetchServices = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/services`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setServices(data);
+      } catch (error) {
+        console.error('Failed to fetch services:', error);
+      }
+    };
+
+    fetchServices();
+  }, []);
+
+  const cardStyle: React.CSSProperties = {
+    position: 'relative',
+    background: 'rgba(255, 255, 255, 0.05)',
+    borderRadius: '24px',
+    padding: '2.5rem 2rem',
+    color: 'white',
+    border: '1px solid rgba(255, 255, 255, 0.2)',
+    overflow: 'hidden',
+    textAlign: 'center',
+    transition: 'transform 0.3s ease',
+  };
+
+  const glowIconStyle: React.CSSProperties = {
+    filter: 'drop-shadow(0 0 8px rgba(100, 200, 255, 0.7))',
+  };
+
+  return (
+    <section style={{ marginBottom: '4rem' }}>
+       <h2 style={{
+        fontSize: '2.5rem',
+        fontWeight: 'bold',
+        color: 'white',
+        margin: '0 0 3rem 0',
+        textAlign: 'center',
+        letterSpacing: '0.02em',
+        textShadow: '0 0 8px rgba(255, 255, 255, 0.3)'
+      }}>
+        SERVICES
+      </h2>
+      <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+        {services.map((item, index) => (
+          <div key={index} style={cardStyle}
+            onMouseEnter={(e) => e.currentTarget.style.transform = 'translateY(-10px)'}
+            onMouseLeave={(e) => e.currentTarget.style.transform = 'translateY(0px)'}
+          >
+            <div style={{...glowIconStyle, marginBottom: '1.5rem'}}>
+              <Icon name={item.icon} size={40} color="#90d8ff" />
+            </div>
+            <h3 style={{
+              fontSize: '1.5rem',
+              fontWeight: 'bold',
+              margin: '0 0 0.75rem 0',
+            }}>{item.title}</h3>
+            <p style={{
+              fontSize: '1rem',
+              margin: 0,
+              lineHeight: 1.6,
+              opacity: 0.8,
+            }}>{item.description}</p>
+          </div>
+        ))}
+      </Grid>
+    </section>
+  );
+};
+
+export default ServicesSectionSample4;

--- a/src/components/organisms/StatsSectionSample4/index.tsx
+++ b/src/components/organisms/StatsSectionSample4/index.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import Grid from '../../atoms/Grid';
+import Icon from '../../atoms/Icon';
+
+interface Stat {
+  label: string;
+  value: string;
+  change: string;
+  icon: string;
+  color: string; // Will be used for glow effect
+}
+
+const StatsSectionSample4 = () => {
+  const [stats, setStats] = useState<Stat[]>([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/stats`);
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        setStats(data);
+      } catch (error) {
+        console.error('Failed to fetch stats:', error);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  const cardStyle: React.CSSProperties = {
+    background: 'rgba(0, 0, 0, 0.2)',
+    backdropFilter: 'blur(10px)',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    borderRadius: '24px',
+    padding: '2rem',
+    textAlign: 'center',
+    color: 'white',
+    transition: 'background 0.3s',
+  };
+
+  return (
+    <section style={{ marginBottom: '4rem' }}>
+      <Grid $cols={4} $tabletCols={2} $mobileCols={1}>
+        {stats.map((stat, index) => (
+          <div key={index} style={cardStyle}>
+            <div style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.75rem' }}>
+              <Icon name={stat.icon} size={18} color="#ffffff" />
+              <h3 style={{ fontSize: '1rem', fontWeight: '500', margin: 0, opacity: 0.8 }}>{stat.label}</h3>
+            </div>
+            <p style={{
+              fontSize: '2.5rem',
+              fontWeight: 'bold',
+              margin: '0 0 0.5rem 0',
+              textShadow: `0 0 10px ${stat.color}, 0 0 20px ${stat.color}`,
+            }}>
+              {stat.value}
+            </p>
+            <p style={{ fontSize: '0.9rem', margin: 0, opacity: 0.7 }}>
+              {stat.change} vs last month
+            </p>
+          </div>
+        ))}
+      </Grid>
+    </section>
+  );
+};
+
+export default StatsSectionSample4;

--- a/src/components/pages/HomePageSample4/index.tsx
+++ b/src/components/pages/HomePageSample4/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import MainLayout from '../../templates/MainLayout';
+import HeroSectionSample4 from '../../organisms/HeroSectionSample4';
+import StatsSectionSample4 from '../../organisms/StatsSectionSample4';
+import ServicesSectionSample4 from '../../organisms/ServicesSectionSample4';
+import ContentGridSample4 from '../../organisms/ContentGridSample4';
+
+/**
+ * ## UI-01-01: Home Page Sample 4 (Futuristic Glassmorphism)
+ * ### Atomic Structure
+ * - Template: MainLayout
+ * - Organism: HeroSectionSample4
+ * - Organism: StatsSectionSample4
+ * - Organism: ServicesSectionSample4
+ * - Organism: ContentGridSample4
+ *
+ * @returns {JSX.Element}
+ */
+const HomePageSample4 = () => {
+  const pageStyle: React.CSSProperties = {
+    background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+    minHeight: '100vh',
+    paddingTop: '2rem',
+    paddingBottom: '4rem',
+  };
+
+  return (
+    <div style={pageStyle}>
+      <MainLayout>
+        <HeroSectionSample4 />
+        <StatsSectionSample4 />
+        <ServicesSectionSample4 />
+        <ContentGridSample4 />
+      </MainLayout>
+    </div>
+  );
+};
+
+export default HomePageSample4;


### PR DESCRIPTION
사용자의 추가 요청에 따라 'Futuristic Glassmorphism' 컨셉의 네 번째 홈페이지 디자인 시안을 구현합니다.

- `/home-sample4` 경로 및 `HomePageSample4` 페이지 추가
- 글래스모피즘 효과를 적용한 `Sample4` 컴포넌트들 생성
- 전체 페이지에 미래지향적인 스타일 적용