### PR TITLE
fix: 샘플3 및 원래 홈의 검색창 중앙 정렬

### DIFF
--- a/src/components/organisms/HeroSection/index.tsx
+++ b/src/components/organisms/HeroSection/index.tsx
@@ -48,7 +48,9 @@ const HeroSection = () => {
         </p>
 
         {/* 중앙 정렬 검색창 */}
-        <SearchBar />
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <SearchBar />
+        </div>
       </div>
     </section>
   );

--- a/src/components/organisms/HeroSectionSample3/index.tsx
+++ b/src/components/organisms/HeroSectionSample3/index.tsx
@@ -35,7 +35,7 @@ const HeroSectionSample3 = () => {
         <br />
         정확한 정보와 통계로 최적의 비즈니스 결정을 내리세요.
       </p>
-      <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
         <SearchBar />
       </div>
     </section>


### PR DESCRIPTION
사용자 피드백을 반영하여 `home-sample3` 및 원래 `HomePage`의 Hero 영역에 있는 검색창이 중앙에 오도록 수정합니다.

`SearchBar` 컴포넌트를 `div`로 감싸고 flexbox를 사용하여 중앙 정렬을 적용하여, 모든 페이지에서 일관된 정렬을 보장합니다.