### PR TITLE
refactor: 루트 페이지 모바일 반응형 스타일 개선

### DIFF
--- a/src/components/molecules/StatCard/index.tsx
+++ b/src/components/molecules/StatCard/index.tsx
@@ -8,11 +8,15 @@ import Icon from '../../atoms/Icon';
 const CardWrapper = styled.div`
   background: ${DESIGN_SYSTEM.gradients.card};
   border-radius: 20px;
-  padding: 2rem;
+  padding: ${DESIGN_SYSTEM.spacing[8]}; /* 2rem */
   box-shadow: ${DESIGN_SYSTEM.shadows.lg};
   border: 1px solid ${DESIGN_SYSTEM.colors.gray[100]};
   position: relative;
   overflow: hidden;
+
+  @media (max-width: 768px) {
+    padding: ${DESIGN_SYSTEM.spacing[6]}; /* 1.5rem */
+  }
 `;
 
 const BackgroundAccent = styled.div<{ color: string }>`
@@ -54,6 +58,10 @@ const ChangeIndicator = styled.div`
   font-size: ${DESIGN_SYSTEM.typography.fontSize.sm[0]};
   font-weight: ${DESIGN_SYSTEM.typography.fontWeight.semibold};
   color: ${DESIGN_SYSTEM.colors.success[600]};
+
+  @media (max-width: 768px) {
+    font-size: ${DESIGN_SYSTEM.typography.fontSize.xs[0]};
+  }
 `;
 
 const ValueText = styled.div`
@@ -63,12 +71,20 @@ const ValueText = styled.div`
   margin-bottom: 0.5rem;
   font-family: ${DESIGN_SYSTEM.typography.fontFamily.mono};
   line-height: 1;
+
+  @media (max-width: 768px) {
+    font-size: ${DESIGN_SYSTEM.typography.fontSize['3xl'][0]};
+  }
 `;
 
 const LabelText = styled.div`
   font-size: ${DESIGN_SYSTEM.typography.fontSize.sm[0]};
   color: ${DESIGN_SYSTEM.colors.gray[600]};
   font-weight: ${DESIGN_SYSTEM.typography.fontWeight.medium};
+
+  @media (max-width: 768px) {
+    font-size: ${DESIGN_SYSTEM.typography.fontSize.xs[0]};
+  }
 `;
 
 // --- DATA MODELS ---

--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -25,6 +25,10 @@ const SectionTitle = styled.h2`
   font-weight: 700;
   color: #111827;
   margin: 0;
+
+  @media (max-width: 768px) {
+    font-size: 1.25rem;
+  }
 `;
 
 const ViewAllButton = styled(Button)`
@@ -49,6 +53,10 @@ const CardContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
 `;
 
 const NewsCard = styled.div`
@@ -61,6 +69,10 @@ const NewsCard = styled.div`
   &:hover {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
     border-color: #d1d5db;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
   }
 `;
 
@@ -93,6 +105,10 @@ const NewsCardTitle = styled.h4`
   color: #111827;
   margin: 0 0 0.75rem 0;
   line-height: 1.4;
+
+  @media (max-width: 768px) {
+    font-size: 0.9rem;
+  }
 `;
 
 const NewsCardSummary = styled.p`
@@ -100,6 +116,10 @@ const NewsCardSummary = styled.p`
   color: #4b5563;
   margin: 0;
   line-height: 1.5;
+
+  @media (max-width: 768px) {
+    font-size: 0.8rem;
+  }
 `;
 
 

--- a/src/components/organisms/ServicesSection/index.tsx
+++ b/src/components/organisms/ServicesSection/index.tsx
@@ -16,6 +16,10 @@ const SectionTitle = styled.h2`
   margin: 0 0 2.5rem 0;
   text-align: center;
   letter-spacing: -0.025em;
+
+  @media (max-width: 768px) {
+    font-size: 1.8rem;
+  }
 `;
 
 const ServiceCard = styled.div<{ gradient: string }>`
@@ -36,6 +40,11 @@ const ServiceCard = styled.div<{ gradient: string }>`
   &:hover {
     transform: translateY(-5px);
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  }
+
+  @media (max-width: 768px) {
+    padding: 1.5rem;
+    min-height: 180px;
   }
 `;
 
@@ -58,6 +67,10 @@ const CardTitle = styled.h3`
   color: white;
   margin: 0 0 0.75rem 0;
   line-height: 1.3;
+
+  @media (max-width: 768px) {
+    font-size: 1.1rem;
+  }
 `;
 
 const CardDescription = styled.p`
@@ -65,6 +78,10 @@ const CardDescription = styled.p`
   color: rgba(255, 255, 255, 0.9);
   margin: 0;
   line-height: 1.5;
+
+  @media (max-width: 768px) {
+    font-size: 0.8rem;
+  }
 `;
 
 // --- DATA MODELS ---


### PR DESCRIPTION
사용자 피드백에 따라 루트 페이지를 구성하는 주요 컴포넌트들의 모바일 반응형 스타일을 개선합니다.

- `768px` 이하의 화면에서 카드형 컴포넌트의 좌우 여백(padding)을 줄여 콘텐츠 영역을 더 확보합니다.
- 모바일 화면에서의 시각적 균형을 위해 전반적인 폰트 크기를 한 단계씩 줄입니다.
- `StatCard`, `ServicesSection`, `ContentGrid` 컴포넌트 내의 `styled-components`에 미디어 쿼리를 추가하여 스타일을 조정합니다.