### PR TITLE
fix: improve mobile responsiveness for announcements

### DIFF
--- a/src/components/molecules/AnnouncementListItem/index.tsx
+++ b/src/components/molecules/AnnouncementListItem/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Icon from '../../atoms/Icon';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
 // --- DATA MODELS ---
 interface Announcement {
@@ -74,6 +75,12 @@ const ItemFooter = styled.div`
   align-items: center;
   font-size: 0.875rem;
   color: #6b7280;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
 `;
 
 const Organization = styled.span``;

--- a/src/components/molecules/Tabs/index.tsx
+++ b/src/components/molecules/Tabs/index.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
 // --- STYLED COMPONENTS ---
 
 const TabsWrapper = styled.div`
   border-bottom: 1px solid #d1d5db; /* gray-300 */
   margin-bottom: 2rem;
+  overflow-x: auto;
+
+  /* Hide scrollbar for cleaner look but keep functionality */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
 `;
 
 const TabList = styled.div`
@@ -16,6 +25,7 @@ const TabList = styled.div`
 const TabButton = styled.button<{ isActive: boolean }>`
   padding: 0.75rem 0.25rem;
   margin: 0 0.75rem;
+  white-space: nowrap; /* Prevent text wrapping */
   font-size: 1rem;
   font-weight: 600;
   border: none;

--- a/src/components/organisms/AnnouncementsDashboard/index.tsx
+++ b/src/components/organisms/AnnouncementsDashboard/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
 // --- STYLED COMPONENTS ---
 
@@ -22,6 +23,10 @@ const StatsGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1.5rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    grid-template-columns: repeat(2, 1fr);
+  }
 `;
 
 const StatCard = styled.div`

--- a/src/components/pages/AnnouncementsPage/index.tsx
+++ b/src/components/pages/AnnouncementsPage/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import AnnouncementList from '../../organisms/AnnouncementList';
 import AnnouncementsDashboard from '../../organisms/AnnouncementsDashboard';
@@ -76,6 +77,10 @@ const PageWrapper = styled.div`
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem 1rem;
+  }
 `;
 
 const PageHeader = styled.header`
@@ -88,6 +93,10 @@ const PageTitle = styled.h1`
   font-weight: 700;
   color: #111827;
   margin-bottom: 0.5rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 2rem;
+  }
 `;
 
 const PageSubtitle = styled.p`

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -134,5 +134,13 @@ export const DESIGN_SYSTEM = {
       extrabold: '800',
       black: '900'
     }
+  },
+  breakpoints: {
+    mobile: '768px',
+    tablet: '1024px',
+  },
+  mediaQueries: {
+    mobile: '(max-width: 768px)',
+    tablet: '(max-width: 1024px)',
   }
 };


### PR DESCRIPTION
This commit addresses feedback about the mobile layout of the announcements page.

- Adds common media query breakpoints to the design system tokens.
- Updates the `AnnouncementsDashboard` to use a 2-column layout on mobile.
- Makes the `Tabs` component horizontally scrollable on mobile.
- Adjusts padding and font sizes on the `AnnouncementsPage` for smaller screens.
- Stacks content in the `AnnouncementListItem` vertically on mobile.