### PR TITLE
feat: make incubation page responsive

### DIFF
--- a/src/components/organisms/IncubationTabs/ApplyView.tsx
+++ b/src/components/organisms/IncubationTabs/ApplyView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Timeline from '../../molecules/Timeline';
 import NoticeCard, { NoticeCardData } from '../../molecules/NoticeCard';
 import Icon from '../../atoms/Icon';
@@ -36,6 +37,10 @@ const SectionTitle = styled.h2`
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid #e5e7eb;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 1.25rem;
+  }
 `;
 
 const DocumentList = styled.div`

--- a/src/components/organisms/IncubationTabs/DashboardView.tsx
+++ b/src/components/organisms/IncubationTabs/DashboardView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Grid from '../../atoms/Grid';
 import KPIGroup from '../KPIGroup';
 import TenantCard, { TenantCardData } from '../../molecules/TenantCard';
@@ -43,6 +44,10 @@ const Section = styled.section`
   display: flex;
   flex-direction: column;
   border: 1px solid #e5e7eb;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem;
+  }
 `;
 
 const SectionHeader = styled.div`
@@ -55,6 +60,10 @@ const SectionHeader = styled.div`
 const SectionTitle = styled.h2`
   font-size: 1.5rem;
   font-weight: 600;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 1.25rem;
+  }
 `;
 
 const ViewAllLink = styled(Link)`

--- a/src/components/organisms/IncubationTabs/TenantsView.tsx
+++ b/src/components/organisms/IncubationTabs/TenantsView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Grid from '../../atoms/Grid';
 import SearchBar from '../../molecules/SearchBar';
 import FilterBar from '../../molecules/FilterBar';
@@ -25,6 +26,11 @@ const ControlsWrapper = styled.div`
   margin-bottom: 2rem;
   flex-wrap: wrap;
   gap: 1rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 // --- COMPONENT ---

--- a/src/components/organisms/IncubationTabs/VacancyView.tsx
+++ b/src/components/organisms/IncubationTabs/VacancyView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Grid from '../../atoms/Grid';
 import SearchBar from '../../molecules/SearchBar';
 import FilterBar from '../../molecules/FilterBar';
@@ -50,6 +51,11 @@ const ControlsWrapper = styled.div`
   margin-bottom: 2rem;
   flex-wrap: wrap;
   gap: 1rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 const CenterSection = styled.section`
@@ -62,6 +68,10 @@ const CenterTitle = styled.h2`
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid #e5e7eb;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 1.25rem;
+  }
 `;
 
 // --- COMPONENT ---

--- a/src/components/pages/IncubationPage/index.tsx
+++ b/src/components/pages/IncubationPage/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import Tabs from '../../molecules/Tabs';
 import DashboardView from '../../organisms/IncubationTabs/DashboardView';
@@ -27,6 +28,10 @@ const PageWrapper = styled.div`
   padding: 2rem;
   animation: ${fadeIn} 0.5s ease-out;
   background: linear-gradient(to bottom, #f9fafb 0%, #ffffff 300px);
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem 1rem;
+  }
 `;
 
 const PageHeader = styled.header`
@@ -36,6 +41,10 @@ const PageHeader = styled.header`
 const PageTitle = styled.h1`
   font-size: 2.5rem;
   font-weight: 700;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 2rem;
+  }
 `;
 
 // --- COMPONENT ---


### PR DESCRIPTION
This commit improves the mobile responsiveness of the /incubation page and its associated tab views (DashboardView, TenantsView, VacancyView, ApplyView).

It applies consistent responsive styles to page containers, section titles, and controls, ensuring a clean and user-friendly layout on smaller screens.