### PR TITLE
feat: make news list and detail pages responsive

### DIFF
--- a/src/components/pages/NewsDetailPage/index.tsx
+++ b/src/components/pages/NewsDetailPage/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useParams, Link } from 'react-router-dom';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import Icon from '../../atoms/Icon';
 
@@ -38,6 +39,10 @@ const PageWrapper = styled.div`
   max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem 1rem;
+  }
 `;
 
 const ArticleHeader = styled.header`
@@ -46,6 +51,10 @@ const ArticleHeader = styled.header`
   border-bottom: 1px solid #e5e7eb;
   background-color: #f9fafb;
   border-radius: 16px;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem;
+  }
 `;
 
 const Title = styled.h1`
@@ -53,12 +62,16 @@ const Title = styled.h1`
   font-weight: 700;
   line-height: 1.3;
   margin-bottom: 1.5rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 1.75rem;
+  }
 `;
 
 const Metadata = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem 2rem;
+  gap: 0.5rem 1.5rem;
   font-size: 0.875rem;
   color: #6b7280;
 `;
@@ -68,10 +81,27 @@ const ArticleBody = styled.div`
   font-size: 1rem;
   color: #374151;
 
-  h2 { font-size: 1.75rem; font-weight: 600; margin: 2rem 0 1rem; }
-  h3 { font-size: 1.25rem; font-weight: 600; margin: 1.5rem 0 1rem; }
-  p { margin-bottom: 1rem; }
-  a { color: #4f46e5; }
+  h2 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 2rem 0 1rem;
+  }
+  h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 1.5rem 0 1rem;
+  }
+  p {
+    margin-bottom: 1rem;
+  }
+  a {
+    color: #4f46e5;
+  }
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    h2 { font-size: 1.5rem; }
+    h3 { font-size: 1.125rem; }
+  }
 `;
 
 const TagContainer = styled.div`

--- a/src/components/pages/NewsListPage/index.tsx
+++ b/src/components/pages/NewsListPage/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import SearchBar from '../../molecules/SearchBar';
 import Pagination from '../../molecules/Pagination';
@@ -44,6 +45,10 @@ const PageWrapper = styled.div`
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem 1rem;
+  }
 `;
 
 const PageHeader = styled.header`
@@ -53,11 +58,20 @@ const PageHeader = styled.header`
   margin-bottom: 2.5rem;
   flex-wrap: wrap;
   gap: 1rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 const PageTitle = styled.h1`
   font-size: 2rem;
   font-weight: 700;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 1.75rem;
+  }
 `;
 
 // --- COMPONENT ---


### PR DESCRIPTION
This commit improves the mobile responsiveness of the /news list and detail pages.

- Adjusts padding, header layouts, and font sizes for mobile screens.
- Ensures a consistent and clean user experience on smaller devices.