### PR TITLE
feat: make tech patents page and table list responsive

### DIFF
--- a/src/components/molecules/TableList/index.tsx
+++ b/src/components/molecules/TableList/index.tsx
@@ -1,7 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
 // --- STYLED COMPONENTS ---
+
+const DesktopOnly = styled.div`
+  display: block;
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    display: none;
+  }
+`;
+
+const MobileOnly = styled.div`
+  display: none;
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    display: block;
+  }
+`;
 
 const TableContainer = styled.div`
   overflow-x: auto;
@@ -39,6 +54,39 @@ const Td = styled.td`
   color: #111827;
 `;
 
+const CardList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Card = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background-color: white;
+  padding: 1.5rem;
+`;
+
+const CardRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid #f3f4f6;
+  }
+`;
+
+const CardLabel = styled.span`
+  font-weight: 600;
+  color: #374151;
+`;
+
+const CardValue = styled.span`
+  color: #111827;
+  text-align: right;
+`;
+
 // --- COMPONENT ---
 
 interface TableListProps {
@@ -49,30 +97,49 @@ interface TableListProps {
 
 const TableList: React.FC<TableListProps> = ({ headers, rows, onRowClick }) => {
   return (
-    <TableContainer>
-      <StyledTable>
-        <THead>
-          <Tr>
-            {headers.map((header, index) => (
-              <Th key={index}>{header}</Th>
-            ))}
-          </Tr>
-        </THead>
-        <tbody>
-          {rows.map((row, rowIndex) => (
-            <Tr
-              key={rowIndex}
-              onClick={() => onRowClick && onRowClick(rowIndex)}
-              style={{ cursor: onRowClick ? 'pointer' : 'default' }}
-            >
-              {row.map((cell, cellIndex) => (
-                <Td key={cellIndex}>{cell}</Td>
+    <>
+      <DesktopOnly>
+        <TableContainer>
+          <StyledTable>
+            <THead>
+              <Tr>
+                {headers.map((header, index) => (
+                  <Th key={index}>{header}</Th>
+                ))}
+              </Tr>
+            </THead>
+            <tbody>
+              {rows.map((row, rowIndex) => (
+                <Tr
+                  key={rowIndex}
+                  onClick={() => onRowClick && onRowClick(rowIndex)}
+                  style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                >
+                  {row.map((cell, cellIndex) => (
+                    <Td key={cellIndex}>{cell}</Td>
+                  ))}
+                </Tr>
               ))}
-            </Tr>
+            </tbody>
+          </StyledTable>
+        </TableContainer>
+      </DesktopOnly>
+
+      <MobileOnly>
+        <CardList>
+          {rows.map((row, rowIndex) => (
+            <Card key={rowIndex} onClick={() => onRowClick && onRowClick(rowIndex)}>
+              {row.map((cell, cellIndex) => (
+                <CardRow key={cellIndex}>
+                  <CardLabel>{headers[cellIndex]}</CardLabel>
+                  <CardValue>{cell}</CardValue>
+                </CardRow>
+              ))}
+            </Card>
           ))}
-        </tbody>
-      </StyledTable>
-    </TableContainer>
+        </CardList>
+      </MobileOnly>
+    </>
   );
 };
 

--- a/src/components/pages/TechPatentsPage/index.tsx
+++ b/src/components/pages/TechPatentsPage/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import SearchBar from '../../molecules/SearchBar';
 import FilterBar from '../../molecules/FilterBar';
@@ -31,6 +32,10 @@ const PageWrapper = styled.div`
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding: 1.5rem 1rem;
+  }
 `;
 
 const PageHeader = styled.header`
@@ -41,6 +46,10 @@ const PageHeader = styled.header`
 const PageTitle = styled.h1`
   font-size: 2.5rem;
   font-weight: 700;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 2rem;
+  }
 `;
 
 const ControlsWrapper = styled.div`
@@ -50,6 +59,11 @@ const ControlsWrapper = styled.div`
   margin-bottom: 2rem;
   flex-wrap: wrap;
   gap: 1rem;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 // --- COMPONENT ---


### PR DESCRIPTION
This commit improves the mobile responsiveness of the /tech-patents page.

- The `TableList` molecule has been refactored to display as a list of cards on mobile devices, significantly improving usability.
- Page containers and controls have also been made responsive.