### PR TITLE
feat: redesign news and events section

### DIFF
--- a/src/components/molecules/NewsCard/index.tsx
+++ b/src/components/molecules/NewsCard/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
 // --- STYLED COMPONENTS ---
 
@@ -13,56 +14,61 @@ const CardLink = styled(Link)`
 
 const CardWrapper = styled.div`
   background-color: white;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  padding: 1rem;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-  transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+  border-radius: 12px;
+  border: 1px solid ${DESIGN_SYSTEM.colors.gray[200]};
+  box-shadow: ${DESIGN_SYSTEM.shadows.sm};
+  transition: all 0.3s ease;
+  min-width: 280px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 
   &:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+    transform: translateY(-8px);
+    box-shadow: ${DESIGN_SYSTEM.shadows.lg};
   }
+`;
+
+const ThumbnailWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: ${DESIGN_SYSTEM.colors.gray[100]};
 `;
 
 const Thumbnail = styled.img`
   width: 100%;
-  height: 180px;
+  height: 100%;
   object-fit: cover;
-  border-radius: 12px;
-  margin-bottom: 1rem;
+`;
+
+const CategoryBadge = styled.span<{ color: string, bgColor: string }>`
+  position: absolute;
+  top: ${DESIGN_SYSTEM.spacing.md};
+  left: ${DESIGN_SYSTEM.spacing.md};
+  padding: ${DESIGN_SYSTEM.spacing.xs} ${DESIGN_SYSTEM.spacing.sm};
+  background-color: ${props => props.bgColor};
+  color: ${props => props.color};
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
 `;
 
 const ContentWrapper = styled.div`
-  padding: 0.5rem;
+  padding: ${DESIGN_SYSTEM.spacing.md};
   display: flex;
   flex-direction: column;
   flex-grow: 1;
 `;
 
 const Title = styled.h3`
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem 0;
+  font-size: 18px;
+  font-weight: 700;
   line-height: 1.4;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.sm} 0;
 
-  /* Ellipsis for single line */
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const Summary = styled.p`
-  font-size: 0.875rem;
-  color: #4b5563;
-  line-height: 1.5;
-  margin: 0 0 1rem 0;
-  flex-grow: 1;
-
-  /* Ellipsis for 2 lines */
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -70,18 +76,28 @@ const Summary = styled.p`
   -webkit-box-orient: vertical;
 `;
 
+const Summary = styled.p`
+  font-size: 14px;
+  color: ${DESIGN_SYSTEM.colors.gray[600]};
+  line-height: 1.6;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.md} 0;
+  flex-grow: 1;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+`;
+
 const Footer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.75rem;
-  color: #6b7280;
-  padding-top: 0.75rem;
-  border-top: 1px solid #f3f4f6;
-`;
-
-const Source = styled.span`
-  font-weight: 500;
+  font-size: 12px;
+  color: ${DESIGN_SYSTEM.colors.gray[500]};
+  padding-top: ${DESIGN_SYSTEM.spacing.sm};
+  border-top: 1px solid ${DESIGN_SYSTEM.colors.gray[100]};
 `;
 
 // --- COMPONENT ---
@@ -93,6 +109,11 @@ export interface NewsCardData {
   thumbnailUrl?: string;
   sourceName: string;
   publishedAt: string;
+  category: {
+    name: string;
+    color: string;
+    bgColor: string;
+  };
 }
 
 interface NewsCardProps {
@@ -103,12 +124,17 @@ const NewsCard: React.FC<NewsCardProps> = ({ news }) => {
   return (
     <CardLink to={`/news/latest/${news.id}`}>
       <CardWrapper>
-        {news.thumbnailUrl && <Thumbnail src={news.thumbnailUrl} alt={news.title} />}
+        <ThumbnailWrapper>
+          {news.thumbnailUrl && <Thumbnail src={news.thumbnailUrl} alt={news.title} loading="lazy" />}
+          <CategoryBadge color={news.category.color} bgColor={news.category.bgColor}>
+            {news.category.name}
+          </CategoryBadge>
+        </ThumbnailWrapper>
         <ContentWrapper>
           <Title>{news.title}</Title>
           <Summary>{news.summary}</Summary>
           <Footer>
-            <Source>{news.sourceName}</Source>
+            <span>{news.sourceName}</span>
             <span>{new Date(news.publishedAt).toLocaleDateString()}</span>
           </Footer>
         </ContentWrapper>

--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -1,260 +1,132 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import Button from '../../atoms/Button';
-import Icon from '../../atoms/Icon';
-import Grid from '../../atoms/Grid';
-import AnnouncementList from '../AnnouncementList';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import NewsCard, { NewsCardData } from '../../molecules/NewsCard';
+import Tabs from '../../molecules/Tabs';
+
+// --- MOCK DATA ---
+const mockNewsData: NewsCardData[] = [
+  {
+    id: 'news-1',
+    title: '혁신적인 암 치료법, CAR-T 세포 치료의 최신 동향',
+    summary: 'CAR-T 세포 치료가 혈액암을 넘어 고형암 정복에 나섰다. 국내외 연구진들의 최신 연구 결과와 임상 현황을 집중 조명한다.',
+    thumbnailUrl: 'https://picsum.photos/seed/news1/400/225',
+    sourceName: '바이오타임즈',
+    publishedAt: '2024-08-14',
+    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
+  },
+  {
+    id: 'news-2',
+    title: 'AI 신약 개발, 딥마인드의 알파폴드2가 가져온 혁명',
+    summary: '단백질 구조 예측 AI 알파폴드2가 신약 개발 패러다임을 바꾸고 있다. 개발 기간 단축과 비용 절감 효과는?',
+    thumbnailUrl: 'https://picsum.photos/seed/news2/400/225',
+    sourceName: '메디컬 투데이',
+    publishedAt: '2024-08-13',
+    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
+  },
+  {
+    id: 'news-3',
+    title: '유전자 가위 기술, 크리스퍼-카스9의 안전성 논란과 미래',
+    summary: '3세대 유전자 가위 기술 크리스퍼-카스9의 오프타겟(off-target) 문제를 해결하기 위한 국내 연구진의 쾌거.',
+    thumbnailUrl: 'https://picsum.photos/seed/news3/400/225',
+    sourceName: '사이언스 포커스',
+    publishedAt: '2024-08-12',
+    category: { name: '행사', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.success[600] },
+  },
+];
 
 // --- STYLED COMPONENTS ---
 
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
+const SectionWrapper = styled.section`
+  margin-bottom: ${DESIGN_SYSTEM.spacing['3xl']};
 `;
 
 const SectionHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
+  text-align: center;
+  margin-bottom: ${DESIGN_SYSTEM.spacing['2xl']};
 `;
 
 const SectionTitle = styled.h2`
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #111827;
-  margin: 0;
+  font-weight: 900;
+  background: ${DESIGN_SYSTEM.gradients.primary};
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.lg} 0;
 
-  @media (max-width: 768px) {
-    font-size: 1.25rem;
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 32px;
+  }
+  @media (min-width: 769px) {
+    font-size: 48px;
   }
 `;
 
-const ViewAllButton = styled(Button)`
+const SectionSubtitle = styled.p`
+  color: ${DESIGN_SYSTEM.colors.gray[600]};
+  max-width: 600px;
+  margin: 0 auto;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 16px;
+  }
+  @media (min-width: 769px) {
+    font-size: 20px;
+  }
+`;
+
+const TabContainer = styled.div`
+  margin-bottom: ${DESIGN_SYSTEM.spacing.xl};
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: none;
-  color: #4f46e5;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
+  justify-content: center;
 `;
 
-const CardContainer = styled.div`
-  background-color: white;
-  border-radius: 20px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-  border: 1px solid #f3f4f6;
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: ${DESIGN_SYSTEM.spacing.lg};
 
-  @media (max-width: 768px) {
-    padding: 1rem;
-  }
-`;
-
-const NewsCard = styled.div`
-  padding: 1.25rem;
-  border-radius: 12px;
-  border: 1px solid #e5e7eb;
-  cursor: pointer;
-  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
-
-  &:hover {
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-    border-color: #d1d5db;
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: ${DESIGN_SYSTEM.spacing.xl};
   }
 
-  @media (max-width: 768px) {
-    padding: 1rem;
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(3, 1fr);
   }
 `;
-
-const NewsCardHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 0.75rem;
-`;
-
-const NewsCardCategory = styled.span`
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  background-color: #6366f1;
-  color: white;
-  border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
-`;
-
-const NewsCardDate = styled.div`
-  font-size: 0.875rem;
-  color: #6b7280;
-`;
-
-const NewsCardTitle = styled.h4`
-  font-size: 1rem;
-  font-weight: 600;
-  color: #111827;
-  margin: 0 0 0.75rem 0;
-  line-height: 1.4;
-
-  @media (max-width: 768px) {
-    font-size: 0.9rem;
-  }
-`;
-
-const NewsCardSummary = styled.p`
-  font-size: 0.875rem;
-  color: #4b5563;
-  margin: 0;
-  line-height: 1.5;
-
-  @media (max-width: 768px) {
-    font-size: 0.8rem;
-  }
-`;
-
-
-// --- DATA MODELS ---
-
-interface AnnouncementFromAPI {
-  id: number;
-  title: string;
-  author: string;
-  created_at: string;
-}
-
-interface NewsFromAPI {
-  id: number;
-  title: string;
-  content: string;
-  category: string;
-  created_at: string;
-}
-
-interface AnnouncementForList {
-  id: number;
-  title: string;
-  organization: string;
-  deadline: string;
-  budget: string;
-  status: 'active' | 'urgent';
-  daysLeft: number;
-}
-
-interface NewsForList {
-  id: number;
-  title: string;
-  summary: string;
-  date: string;
-  category: string;
-}
 
 // --- COMPONENT ---
 
 const ContentGrid = () => {
-  const [announcements, setAnnouncements] = useState<AnnouncementForList[]>([]);
-  const [news, setNews] = useState<NewsForList[]>([]);
+  const [activeTab, setActiveTab] = useState('all');
+  const TABS = [
+    { id: 'all', label: '전체' },
+    { id: 'news', label: '뉴스' },
+    { id: 'event', label: '행사' },
+    { id: 'announcement', label: '공지' },
+  ];
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const [announcementsResponse, newsResponse] = await Promise.all([
-          fetch(`${process.env.REACT_APP_API_URL}/api/announcements?limit=3`),
-          fetch(`${process.env.REACT_APP_API_URL}/api/news?limit=3`)
-        ]);
-
-        if (!announcementsResponse.ok || !newsResponse.ok) {
-          throw new Error('Network response was not ok');
-        }
-
-        const announcementsData: AnnouncementFromAPI[] = await announcementsResponse.json();
-        const newsData: NewsFromAPI[] = await newsResponse.json();
-
-        const transformedAnnouncements = announcementsData.map(item => ({
-          id: item.id,
-          title: item.title,
-          organization: item.author,
-          deadline: new Date(new Date(item.created_at).getTime() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString(),
-          budget: 'N/A',
-          status: 'active' as 'active',
-          daysLeft: 30,
-        }));
-
-        const transformedNews = newsData.map(item => ({
-          id: item.id,
-          title: item.title,
-          summary: item.content.substring(0, 100) + '...',
-          date: new Date(item.created_at).toLocaleDateString(),
-          category: item.category === 'news' ? '산업뉴스' : '공지',
-        }));
-
-        setAnnouncements(transformedAnnouncements);
-        setNews(transformedNews);
-
-      } catch (error) {
-        console.error('Failed to fetch content grid data:', error);
-      }
-    };
-
-    fetchData();
-  }, []);
+  // In a real app, this would filter the data based on the activeTab
+  const filteredData = mockNewsData;
 
   return (
-    <Grid $cols={2} $tabletCols={2} $mobileCols={1} style={{ marginBottom: '4rem' }}>
-      {/* 최신 공고 */}
-      <Section>
-        <SectionHeader>
-          <SectionTitle>최신 공고</SectionTitle>
-          <Link to="/announcements" style={{ textDecoration: 'none' }}>
-            <ViewAllButton>
-              전체보기
-              <Icon name="arrowRight" size={16} />
-            </ViewAllButton>
-          </Link>
-        </SectionHeader>
+    <SectionWrapper>
+      <SectionHeader>
+        <SectionTitle>News & Events</SectionTitle>
+        <SectionSubtitle>
+          전북 바이오 산업의 최신 소식과 동향을 한눈에 확인하세요.
+        </SectionSubtitle>
+      </SectionHeader>
+      <TabContainer>
+        <Tabs tabs={TABS} activeTab={activeTab} onTabClick={setActiveTab} />
+      </TabContainer>
 
-        <CardContainer>
-          <AnnouncementList announcements={announcements} />
-        </CardContainer>
-      </Section>
-
-      {/* 최신 뉴스 */}
-      <Section>
-        <SectionHeader>
-          <SectionTitle>최신 뉴스</SectionTitle>
-          <Link to="/news/latest" style={{ textDecoration: 'none' }}>
-            <ViewAllButton>
-              전체보기
-              <Icon name="arrowRight" size={16} />
-            </ViewAllButton>
-          </Link>
-        </SectionHeader>
-
-        <CardContainer>
-          {news.map((item) => (
-            <Link key={item.id} to={`/news/latest/${item.id}`} style={{ textDecoration: 'none' }}>
-              <NewsCard>
-                <NewsCardHeader>
-                  <NewsCardCategory>{item.category}</NewsCardCategory>
-                  <NewsCardDate>{item.date}</NewsCardDate>
-                </NewsCardHeader>
-                <NewsCardTitle>{item.title}</NewsCardTitle>
-                <NewsCardSummary>{item.summary}</NewsCardSummary>
-              </NewsCard>
-            </Link>
-          ))}
-        </CardContainer>
-      </Section>
-    </Grid>
+      <Grid>
+        {filteredData.map(item => (
+          <NewsCard key={item.id} news={item} />
+        ))}
+      </Grid>
+    </SectionWrapper>
   );
 };
 

--- a/src/components/pages/NewsDashboardPage/index.tsx
+++ b/src/components/pages/NewsDashboardPage/index.tsx
@@ -7,12 +7,14 @@ import NewsCard, { NewsCardData } from '../../molecules/NewsCard';
 import EventCard, { EventCardData } from '../../molecules/EventCard';
 
 // --- MOCK DATA ---
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+
 const mockNewsPreview: NewsCardData[] = [
-  { id: 'news-1', title: '혁신적인 암 치료법, CAR-T 세포 치료의 최신 동향', summary: 'CAR-T 세포 치료가 혈액암을 넘어 고형암 정복에 나섰다.', thumbnailUrl: 'https://picsum.photos/seed/news1/400/225', sourceName: '바이오타임즈', publishedAt: '2024-08-14' },
-  { id: 'news-2', title: 'AI 신약 개발, 딥마인드의 알파폴드2가 가져온 혁명', summary: '단백질 구조 예측 AI 알파폴드2가 신약 개발 패러다임을 바꾸고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news2/400/225', sourceName: '메디컬 투데이', publishedAt: '2024-08-13' },
-  { id: 'news-3', title: '유전자 가위 기술, 크리스퍼-카스9의 안전성 논란과 미래', summary: '3세대 유전자 가위 기술 크리스퍼-카스9의 오프타겟(off-target) 문제를 해결하기 위한 국내 연구진의 쾌거.', thumbnailUrl: 'https://picsum.photos/seed/news3/400/225', sourceName: '사이언스 포커스', publishedAt: '2024-08-12' },
-  { id: 'news-4', title: '마이크로바이옴, 제2의 게놈 프로젝트로 부상', summary: '장내 미생물 생태계, 마이크로바이옴이 난치병 치료의 새로운 해법으로 떠오르고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news4/400/225', sourceName: '헬스조선', publishedAt: '2024-08-11' },
-  { id: 'news-5', title: '디지털 치료제(DTx), 미래 의료의 핵심으로', summary: '소프트웨어를 이용해 질병을 치료하는 디지털 치료제(DTx) 시장이 본격 개화하고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news5/400/225', sourceName: '약업신문', publishedAt: '2024-08-10' },
+  { id: 'news-1', title: '혁신적인 암 치료법, CAR-T 세포 치료의 최신 동향', summary: 'CAR-T 세포 치료가 혈액암을 넘어 고형암 정복에 나섰다.', thumbnailUrl: 'https://picsum.photos/seed/news1/400/225', sourceName: '바이오타임즈', publishedAt: '2024-08-14', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-2', title: 'AI 신약 개발, 딥마인드의 알파폴드2가 가져온 혁명', summary: '단백질 구조 예측 AI 알파폴드2가 신약 개발 패러다임을 바꾸고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news2/400/225', sourceName: '메디컬 투데이', publishedAt: '2024-08-13', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-3', title: '유전자 가위 기술, 크리스퍼-카스9의 안전성 논란과 미래', summary: '3세대 유전자 가위 기술 크리스퍼-카스9의 오프타겟(off-target) 문제를 해결하기 위한 국내 연구진의 쾌거.', thumbnailUrl: 'https://picsum.photos/seed/news3/400/225', sourceName: '사이언스 포커스', publishedAt: '2024-08-12', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-4', title: '마이크로바이옴, 제2의 게놈 프로젝트로 부상', summary: '장내 미생물 생태계, 마이크로바이옴이 난치병 치료의 새로운 해법으로 떠오르고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news4/400/225', sourceName: '헬스조선', publishedAt: '2024-08-11', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-5', title: '디지털 치료제(DTx), 미래 의료의 핵심으로', summary: '소프트웨어를 이용해 질병을 치료하는 디지털 치료제(DTx) 시장이 본격 개화하고 있다.', thumbnailUrl: 'https://picsum.photos/seed/news5/400/225', sourceName: '약업신문', publishedAt: '2024-08-10', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
 ];
 
 const mockEventsPreview: EventCardData[] = [

--- a/src/components/pages/NewsListPage/index.tsx
+++ b/src/components/pages/NewsListPage/index.tsx
@@ -16,6 +16,7 @@ const mockNewsList: NewsCardData[] = [
     thumbnailUrl: 'https://picsum.photos/seed/news1/400/225',
     sourceName: '바이오타임즈',
     publishedAt: '2024-08-14',
+    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
   },
   {
     id: 'news-2',
@@ -24,6 +25,7 @@ const mockNewsList: NewsCardData[] = [
     thumbnailUrl: 'https://picsum.photos/seed/news2/400/225',
     sourceName: '메디컬 투데이',
     publishedAt: '2024-08-13',
+    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
   },
   {
     id: 'news-3',
@@ -32,10 +34,11 @@ const mockNewsList: NewsCardData[] = [
     thumbnailUrl: 'https://picsum.photos/seed/news3/400/225',
     sourceName: '사이언스 포커스',
     publishedAt: '2024-08-12',
+    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
   },
-  { id: 'news-4', title: '마이크로바이옴, 제2의 게놈 프로젝트로 부상', summary: '장내 미생물 생태계, 마이크로바이옴이 난치병 치료의 새로운 해법으로 떠오르고 있다. 관련 시장 동향 분석.', thumbnailUrl: 'https://picsum.photos/seed/news4/400/225', sourceName: '헬스조선', publishedAt: '2024-08-11' },
-  { id: 'news-5', title: '디지털 치료제(DTx), 미래 의료의 핵심으로', summary: '소프트웨어를 이용해 질병을 치료하는 디지털 치료제(DTx) 시장이 본격 개화하고 있다. 국내 규제 현황과 전망은?', thumbnailUrl: 'https://picsum.photos/seed/news5/400/225', sourceName: '약업신문', publishedAt: '2024-08-10' },
-  { id: 'news-6', title: '뇌-컴퓨터 인터페이스(BCI), 상용화 어디까지 왔나', summary: '일론 머스크의 뉴럴링크를 비롯한 BCI 기술의 발전 현황과 윤리적 과제를 짚어본다.', thumbnailUrl: 'https://picsum.photos/seed/news6/400/225', sourceName: '테크월드', publishedAt: '2024-08-09' },
+  { id: 'news-4', title: '마이크로바이옴, 제2의 게놈 프로젝트로 부상', summary: '장내 미생물 생태계, 마이크로바이옴이 난치병 치료의 새로운 해법으로 떠오르고 있다. 관련 시장 동향 분석.', thumbnailUrl: 'https://picsum.photos/seed/news4/400/225', sourceName: '헬스조선', publishedAt: '2024-08-11', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-5', title: '디지털 치료제(DTx), 미래 의료의 핵심으로', summary: '소프트웨어를 이용해 질병을 치료하는 디지털 치료제(DTx) 시장이 본격 개화하고 있다. 국내 규제 현황과 전망은?', thumbnailUrl: 'https://picsum.photos/seed/news5/400/225', sourceName: '약업신문', publishedAt: '2024-08-10', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
+  { id: 'news-6', title: '뇌-컴퓨터 인터페이스(BCI), 상용화 어디까지 왔나', summary: '일론 머스크의 뉴럴링크를 비롯한 BCI 기술의 발전 현황과 윤리적 과제를 짚어본다.', thumbnailUrl: 'https://picsum.photos/seed/news6/400/225', sourceName: '테크월드', publishedAt: '2024-08-09', category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] } },
 ];
 
 


### PR DESCRIPTION
This commit introduces the first phase of a complete redesign for the "News & Events" section, based on user specifications.

- Redesigns the `NewsCard` molecule with a modern layout, responsive behavior, and new data fields.
- Refactors the `ContentGrid` organism to serve as the new section container, adding a prominent header and category tabs.
- Implements a new responsive grid layout (1-2-3 columns).