### PR TITLE
feat: Revamp News & Events Page

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from ..models.announcement import Announcement, FileLink, RelatedLink
 from ..models.company import Company
 from ..models.infra import Infra
-from ..models.content import News, Tech
+from ..models.content import News, Event, Tech
 from ..models.consultation import Consultation
 from ..models.user import UserInDB
 from ..models.service import Service
@@ -213,51 +213,73 @@ news_db: list[News] = [
     News(
         id=1,
         title='전북 바이오 특화단지 유치 성공',
-        content='정부가 전북을 바이오 특화단지로 최종 선정했습니다. 이로써 지역 내 바이오 산업의 성장이 기대됩니다.',
+        summary='정부가 전북을 바이오 특화단지로 최종 선정했습니다. 이로써 지역 내 바이오 산업의 성장이 기대됩니다.',
+        content='정부가 전북을 바이오 특화단지로 최종 선정했습니다. 이로써 지역 내 바이오 산업의 성장이 기대됩니다. 상세 내용은...',
         category='news',
-        created_at=datetime(2025, 8, 12, 11, 0, 0)
+        created_at=datetime(2025, 8, 12, 11, 0, 0),
+        sourceName='전북도청',
+        thumbnailUrl='https://picsum.photos/seed/news1/400/225'
     ),
     News(
         id=2,
         title='시스템 점검 안내 (09/01 02:00 ~ 04:00)',
+        summary='더 나은 서비스 제공을 위해 시스템 정기 점검을 실시합니다.',
         content='더 나은 서비스 제공을 위해 시스템 정기 점검을 실시합니다. 점검 시간에는 서비스 이용이 일시 중단될 수 있습니다.',
         category='notice',
-        created_at=datetime(2025, 8, 11, 17, 0, 0)
+        created_at=datetime(2025, 8, 11, 17, 0, 0),
+        sourceName='관리팀',
+        thumbnailUrl='https://picsum.photos/seed/notice1/400/225'
     ),
     News(
         id=3,
         title='익산 국가식품클러스터, K-푸드 전진기지로 발돋움',
-        content='익산 국가식품클러스터가 국내외 식품 시장에서 주목받으며 K-푸드의 중심으로 떠오르고 있습니다.',
+        summary='익산 국가식품클러스터가 국내외 식품 시장에서 주목받으며 K-푸드의 중심으로 떠오르고 있습니다.',
+        content='익산 국가식품클러스터가 국내외 식품 시장에서 주목받으며 K-푸드의 중심으로 떠오르고 있습니다. 상세 내용은...',
         category='news',
-        created_at=datetime(2025, 8, 15, 9, 0, 0)
+        created_at=datetime(2025, 8, 15, 9, 0, 0),
+        sourceName='농림축산식품부',
+        thumbnailUrl='https://picsum.photos/seed/news2/400/225'
     ),
-    News(
-        id=4,
-        title='정읍 방사선융합기술원, 신약 개발 새 지평 열어',
-        content='정읍에 위치한 한국원자력연구원 방사선융합기술원이 방사선 기술을 이용한 혁신적인 신약 개발에 성공했습니다.',
-        category='news',
-        created_at=datetime(2025, 8, 14, 14, 0, 0)
+]
+
+events_db: list[Event] = [
+    Event(
+        id=1,
+        title='제12회 국제 바이오산업 컨퍼런스',
+        summary='글로벌 바이오 산업의 최신 동향과 미래 전망을 논의하는 국제 컨퍼런스입니다. 사전 등록 시 할인 혜택이 제공됩니다.',
+        thumbnailUrl='https://picsum.photos/seed/event1/400/225',
+        eventStartAt=datetime(2025, 9, 5, 9, 0, 0),
+        eventEndAt=datetime(2025, 9, 6, 18, 0, 0),
+        locationType='offline',
+        locationName='전주 컨벤션센터',
+        host='전북바이오융합산업진흥원',
+        registerDeadline=datetime(2025, 8, 31, 23, 59, 59),
+        status='예정'
     ),
-    News(
-        id=5,
-        title='전주 농생명 혁신성장위원회 출범',
-        content='전주시가 농생명 산업의 혁신 성장을 이끌기 위한 민관 협력 위원회를 공식 출범시켰습니다.',
-        category='news',
-        created_at=datetime(2025, 8, 13, 10, 0, 0)
+    Event(
+        id=2,
+        title='AI 기반 신약 개발 온라인 세미나',
+        summary='인공지능을 활용한 신약 개발의 최신 사례와 기술을 소개하는 웨비나입니다. 누구나 무료로 참여할 수 있습니다.',
+        thumbnailUrl='https://picsum.photos/seed/event2/400/225',
+        eventStartAt=datetime(2025, 8, 25, 14, 0, 0),
+        eventEndAt=datetime(2025, 8, 25, 16, 0, 0),
+        locationType='online',
+        host='한국생명공학연구원',
+        registerDeadline=datetime(2025, 8, 24, 18, 0, 0),
+        status='진행중'
     ),
-    News(
-        id=6,
-        title='플랫폼 이용약관 개정 안내',
-        content='2025년 9월 1일부터 새로운 이용약관이 적용됩니다. 변경된 내용을 확인해주시기 바랍니다.',
-        category='notice',
-        created_at=datetime(2025, 8, 10, 0, 0, 0)
-    ),
-    News(
-        id=7,
-        title='김제 민간육종연구단지, 글로벌 종자 강국 도약의 발판',
-        content='김제에 위치한 민간육종연구단지가 국내 종자 산업의 경쟁력을 세계적인 수준으로 끌어올리고 있습니다.',
-        category='news',
-        created_at=datetime(2025, 8, 9, 11, 20, 0)
+    Event(
+        id=3,
+        title='농생명 기술 투자유치 설명회(IR)',
+        summary='유망 농생명 기술을 보유한 스타트업 및 중소기업을 위한 투자유치 설명회입니다.',
+        thumbnailUrl='https://picsum.photos/seed/event3/400/225',
+        eventStartAt=datetime(2025, 8, 1, 10, 0, 0),
+        eventEndAt=datetime(2025, 8, 1, 17, 0, 0),
+        locationType='hybrid',
+        locationName='전북창조경제혁신센터',
+        host='농업기술실용화재단',
+        registerDeadline=datetime(2025, 7, 25, 18, 0, 0),
+        status='마감'
     )
 ]
 

--- a/backend/models/content.py
+++ b/backend/models/content.py
@@ -1,13 +1,30 @@
-from pydantic import BaseModel
-from typing import Optional
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
 from datetime import datetime
 
 class News(BaseModel):
     id: int
     title: str
+    summary: Optional[str] = None
     content: str
-    category: str  # 'news' or 'notice'
+    category: Literal['news', 'notice']
     created_at: datetime
+    sourceName: Optional[str] = None
+    thumbnailUrl: Optional[str] = None
+
+class Event(BaseModel):
+    id: int
+    title: str
+    summary: Optional[str] = None
+    thumbnailUrl: Optional[str] = None
+    category: Literal['event'] = 'event'
+    eventStartAt: datetime
+    eventEndAt: datetime
+    locationType: Literal['online', 'offline', 'hybrid']
+    locationName: Optional[str] = None
+    host: str
+    registerDeadline: Optional[datetime] = None
+    status: Literal['예정', '진행중', '마감']
 
 class Tech(BaseModel):
     id: int

--- a/backend/routers/content.py
+++ b/backend/routers/content.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, HTTPException, status
 from typing import List
 
-from ..models.content import News, Tech
-from ..db.mock_data import news_db, techs_db
+from ..models.content import News, Event, Tech
+from ..db.mock_data import news_db, events_db, techs_db
 
 router = APIRouter(
     tags=["Content"]
@@ -25,6 +25,25 @@ def get_news_item(news_id: int):
     UI-04-02: Get a single news or notice item by ID.
     """
     item = next((n for n in news_db if n.id == news_id), None)
+    if item is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return item
+
+@router.get("/events", response_model=List[Event], tags=["Content"])
+def get_events_list(limit: Optional[int] = None):
+    """
+    Get a list of all events.
+    """
+    if limit:
+        return events_db[:limit]
+    return events_db
+
+@router.get("/events/{event_id}", response_model=Event, tags=["Content"])
+def get_event_item(event_id: int):
+    """
+    Get a single event item by ID.
+    """
+    item = next((e for e in events_db if e.id == event_id), None)
     if item is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
     return item

--- a/src/components/molecules/EventCard/index.tsx
+++ b/src/components/molecules/EventCard/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+import { Event } from '../../../../types/api';
 
-// --- STYLED COMPONENTS ---
+// --- STYLED COMPONENTS (Shared with NewsCard) ---
 
 const CardLink = styled(Link)`
   text-decoration: none;
@@ -13,49 +15,60 @@ const CardLink = styled(Link)`
 
 const CardWrapper = styled.div`
   background-color: white;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-  transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+  border-radius: 12px;
+  border: 1px solid ${DESIGN_SYSTEM.colors.gray[200]};
+  box-shadow: ${DESIGN_SYSTEM.shadows.sm};
+  transition: all 0.3s ease;
+  min-width: 280px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
 
   &:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+    transform: translateY(-8px);
+    box-shadow: ${DESIGN_SYSTEM.shadows.lg};
   }
+`;
+
+const ThumbnailWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: ${DESIGN_SYSTEM.colors.gray[100]};
 `;
 
 const Thumbnail = styled.img`
   width: 100%;
-  height: 180px;
+  height: 100%;
   object-fit: cover;
 `;
 
+const CategoryBadge = styled.span<{ color: string, bgColor: string }>`
+  position: absolute;
+  top: ${DESIGN_SYSTEM.spacing.md};
+  left: ${DESIGN_SYSTEM.spacing.md};
+  padding: ${DESIGN_SYSTEM.spacing.xs} ${DESIGN_SYSTEM.spacing.sm};
+  background-color: ${props => props.bgColor};
+  color: ${props => props.color};
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+`;
+
 const ContentWrapper = styled.div`
-  padding: 1rem;
+  padding: ${DESIGN_SYSTEM.spacing.md};
   display: flex;
   flex-direction: column;
   flex-grow: 1;
 `;
 
 const Title = styled.h3`
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const Summary = styled.p`
-  font-size: 0.875rem;
-  color: #4b5563;
-  line-height: 1.5;
-  margin: 0 0 1rem 0;
-  flex-grow: 1;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.4;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.sm} 0;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -63,76 +76,71 @@ const Summary = styled.p`
   -webkit-box-orient: vertical;
 `;
 
-const InfoRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  color: #6b7280;
-  margin-bottom: 0.5rem;
+const Summary = styled.p`
+  font-size: 14px;
+  color: ${DESIGN_SYSTEM.colors.gray[600]};
+  line-height: 1.6;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.md} 0;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 `;
 
 const Footer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.75rem;
-  color: #6b7280;
-  padding-top: 1rem;
-  border-top: 1px solid #f3f4f6;
+  font-size: 12px;
+  color: ${DESIGN_SYSTEM.colors.gray[500]};
+  padding-top: ${DESIGN_SYSTEM.spacing.sm};
+  border-top: 1px solid ${DESIGN_SYSTEM.colors.gray[100]};
 `;
 
-const Badge = styled.span<{ type: 'online' | 'offline' | 'hybrid' }>`
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-weight: 500;
-  background-color: ${props => props.type === 'online' ? '#dbeafe' : '#fee2e2'};
-  color: ${props => props.type === 'online' ? '#1e40af' : '#991b1b'};
+const StatusBadge = styled.span<{ status: string }>`
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 12px;
+  background-color: ${({ status, theme }) => {
+    if (status === '예정') return DESIGN_SYSTEM.colors.primary[100];
+    if (status === '진행중') return DESIGN_SYSTEM.colors.success[100];
+    return DESIGN_SYSTEM.colors.gray[200];
+  }};
+  color: ${({ status, theme }) => {
+    if (status === '예정') return DESIGN_SYSTEM.colors.primary[700];
+    if (status === '진행중') return DESIGN_SYSTEM.colors.success[700];
+    return DESIGN_SYSTEM.colors.gray[600];
+  }};
 `;
+
 
 // --- COMPONENT ---
 
-export interface EventCardData {
-  id: string;
-  title: string;
-  summary?: string;
-  thumbnailUrl?: string;
-  eventStartAt: string;
-  eventEndAt: string;
-  locationType: 'online' | 'offline' | 'hybrid';
-  locationName?: string;
-  host: string;
-  registerDeadline?: string;
-}
-
 interface EventCardProps {
-  event: EventCardData;
+  event: Event;
 }
 
 const EventCard: React.FC<EventCardProps> = ({ event }) => {
   const formatDate = (dateStr: string) => new Date(dateStr).toLocaleDateString();
 
-  const dDay = event.registerDeadline ? Math.ceil((new Date(event.registerDeadline).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : null;
-
   return (
     <CardLink to={`/events/${event.id}`}>
       <CardWrapper>
-        {event.thumbnailUrl && <Thumbnail src={event.thumbnailUrl} alt={event.title} />}
+        <ThumbnailWrapper>
+          {event.thumbnailUrl && <Thumbnail src={event.thumbnailUrl} alt={event.title} loading="lazy" />}
+          <CategoryBadge color="#FFFFFF" bgColor={DESIGN_SYSTEM.colors.success[600]}>
+            행사
+          </CategoryBadge>
+        </ThumbnailWrapper>
         <ContentWrapper>
           <Title>{event.title}</Title>
-          <InfoRow>
-            <span>🗓️</span>
-            <span>{formatDate(event.eventStartAt)} ~ {formatDate(event.eventEndAt)}</span>
-          </InfoRow>
-          <InfoRow>
-            <span>📍</span>
-            <span>{event.locationType === 'online' ? '온라인' : event.locationName}</span>
-          </InfoRow>
           {event.summary && <Summary>{event.summary}</Summary>}
           <Footer>
             <span>{event.host}</span>
-            {dDay !== null && dDay >= 0 && <Badge type={event.locationType}>D-{dDay}</Badge>}
-            {dDay !== null && dDay < 0 && <Badge type='offline'>마감</Badge>}
+            <StatusBadge status={event.status}>{event.status}</StatusBadge>
           </Footer>
         </ContentWrapper>
       </CardWrapper>

--- a/src/components/molecules/NewsCard/index.tsx
+++ b/src/components/molecules/NewsCard/index.tsx
@@ -102,32 +102,27 @@ const Footer = styled.div`
 
 // --- COMPONENT ---
 
-export interface NewsCardData {
-  id: string;
-  title: string;
-  summary: string;
-  thumbnailUrl?: string;
-  sourceName: string;
-  publishedAt: string;
-  category: {
-    name: string;
-    color: string;
-    bgColor: string;
-  };
-}
+import { News } from '../../../../types/api';
+
+const CATEGORY_STYLES = {
+  news: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
+  notice: { name: '공지', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.gray[600] },
+};
 
 interface NewsCardProps {
-  news: NewsCardData;
+  news: News;
 }
 
 const NewsCard: React.FC<NewsCardProps> = ({ news }) => {
+  const categoryStyle = CATEGORY_STYLES[news.category] || CATEGORY_STYLES.news;
+
   return (
     <CardLink to={`/news/latest/${news.id}`}>
       <CardWrapper>
         <ThumbnailWrapper>
           {news.thumbnailUrl && <Thumbnail src={news.thumbnailUrl} alt={news.title} loading="lazy" />}
-          <CategoryBadge color={news.category.color} bgColor={news.category.bgColor}>
-            {news.category.name}
+          <CategoryBadge color={categoryStyle.color} bgColor={categoryStyle.bgColor}>
+            {categoryStyle.name}
           </CategoryBadge>
         </ThumbnailWrapper>
         <ContentWrapper>
@@ -135,7 +130,7 @@ const NewsCard: React.FC<NewsCardProps> = ({ news }) => {
           <Summary>{news.summary}</Summary>
           <Footer>
             <span>{news.sourceName}</span>
-            <span>{new Date(news.publishedAt).toLocaleDateString()}</span>
+            <span>{new Date(news.created_at).toLocaleDateString()}</span>
           </Footer>
         </ContentWrapper>
       </CardWrapper>

--- a/src/components/organisms/ContentGrid/index.tsx
+++ b/src/components/organisms/ContentGrid/index.tsx
@@ -1,44 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import { DESIGN_SYSTEM } from '../../../styles/tokens';
-import NewsCard, { NewsCardData } from '../../molecules/NewsCard';
+import NewsCard from '../../molecules/NewsCard';
+import EventCard from '../../molecules/EventCard';
 import Tabs from '../../molecules/Tabs';
-
-// --- MOCK DATA ---
-const mockNewsData: NewsCardData[] = [
-  {
-    id: 'news-1',
-    title: '혁신적인 암 치료법, CAR-T 세포 치료의 최신 동향',
-    summary: 'CAR-T 세포 치료가 혈액암을 넘어 고형암 정복에 나섰다. 국내외 연구진들의 최신 연구 결과와 임상 현황을 집중 조명한다.',
-    thumbnailUrl: 'https://picsum.photos/seed/news1/400/225',
-    sourceName: '바이오타임즈',
-    publishedAt: '2024-08-14',
-    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
-  },
-  {
-    id: 'news-2',
-    title: 'AI 신약 개발, 딥마인드의 알파폴드2가 가져온 혁명',
-    summary: '단백질 구조 예측 AI 알파폴드2가 신약 개발 패러다임을 바꾸고 있다. 개발 기간 단축과 비용 절감 효과는?',
-    thumbnailUrl: 'https://picsum.photos/seed/news2/400/225',
-    sourceName: '메디컬 투데이',
-    publishedAt: '2024-08-13',
-    category: { name: '뉴스', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.primary[600] },
-  },
-  {
-    id: 'news-3',
-    title: '유전자 가위 기술, 크리스퍼-카스9의 안전성 논란과 미래',
-    summary: '3세대 유전자 가위 기술 크리스퍼-카스9의 오프타겟(off-target) 문제를 해결하기 위한 국내 연구진의 쾌거.',
-    thumbnailUrl: 'https://picsum.photos/seed/news3/400/225',
-    sourceName: '사이언스 포커스',
-    publishedAt: '2024-08-12',
-    category: { name: '행사', color: '#FFFFFF', bgColor: DESIGN_SYSTEM.colors.success[600] },
-  },
-];
+import { useNewsAndEvents } from '../../../hooks/useNewsAndEvents';
+import { ContentItem, News, Event } from '../../../types/api';
+import Button from '../../atoms/Button';
 
 // --- STYLED COMPONENTS ---
 
 const SectionWrapper = styled.section`
-  margin-bottom: ${DESIGN_SYSTEM.spacing['3xl']};
+  padding: ${DESIGN_SYSTEM.spacing['3xl']} ${DESIGN_SYSTEM.spacing.md};
+  background-color: ${DESIGN_SYSTEM.colors.gray[50]};
 `;
 
 const SectionHeader = styled.div`
@@ -47,31 +21,19 @@ const SectionHeader = styled.div`
 `;
 
 const SectionTitle = styled.h2`
+  font-size: 48px;
   font-weight: 900;
   background: ${DESIGN_SYSTEM.gradients.primary};
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   margin: 0 0 ${DESIGN_SYSTEM.spacing.lg} 0;
-
-  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    font-size: 32px;
-  }
-  @media (min-width: 769px) {
-    font-size: 48px;
-  }
 `;
 
 const SectionSubtitle = styled.p`
+  font-size: 20px;
   color: ${DESIGN_SYSTEM.colors.gray[600]};
   max-width: 600px;
   margin: 0 auto;
-
-  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    font-size: 16px;
-  }
-  @media (min-width: 769px) {
-    font-size: 20px;
-  }
 `;
 
 const TabContainer = styled.div`
@@ -83,11 +45,11 @@ const TabContainer = styled.div`
 const Grid = styled.div`
   display: grid;
   grid-template-columns: 1fr;
-  gap: ${DESIGN_SYSTEM.spacing.lg};
+  gap: 24px;
 
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
-    gap: ${DESIGN_SYSTEM.spacing.xl};
+    gap: 32px;
   }
 
   @media (min-width: 1024px) {
@@ -95,19 +57,45 @@ const Grid = styled.div`
   }
 `;
 
+const LoadMoreContainer = styled.div`
+  text-align: center;
+  margin-top: ${DESIGN_SYSTEM.spacing['2xl']};
+`;
+
+const EmptyStateContainer = styled.div`
+  text-align: center;
+  padding: ${DESIGN_SYSTEM.spacing['3xl']} 0;
+  color: ${DESIGN_SYSTEM.colors.gray[500]};
+`;
+
 // --- COMPONENT ---
 
 const ContentGrid = () => {
   const [activeTab, setActiveTab] = useState('all');
+  const { data, isLoading, isError } = useNewsAndEvents();
+
   const TABS = [
     { id: 'all', label: '전체' },
     { id: 'news', label: '뉴스' },
     { id: 'event', label: '행사' },
-    { id: 'announcement', label: '공지' },
+    { id: 'notice', label: '공지' },
   ];
 
-  // In a real app, this would filter the data based on the activeTab
-  const filteredData = mockNewsData;
+  const filteredData = useMemo(() => {
+    if (!data) return [];
+    if (activeTab === 'all') return data;
+    if (activeTab === 'notice') {
+      return data.filter(item => 'category' in item && item.category === 'notice');
+    }
+    return data.filter(item => item.category === activeTab);
+  }, [data, activeTab]);
+
+  const renderCard = (item: ContentItem) => {
+    if (item.category === 'event') {
+      return <EventCard key={`event-${item.id}`} event={item as Event} />;
+    }
+    return <NewsCard key={`news-${item.id}`} news={item as News} />;
+  };
 
   return (
     <SectionWrapper>
@@ -121,11 +109,25 @@ const ContentGrid = () => {
         <Tabs tabs={TABS} activeTab={activeTab} onTabClick={setActiveTab} />
       </TabContainer>
 
-      <Grid>
-        {filteredData.map(item => (
-          <NewsCard key={item.id} news={item} />
-        ))}
-      </Grid>
+      {isLoading && <p>Loading...</p>}
+      {isError && <p>Error loading data.</p>}
+
+      {!isLoading && !isError && filteredData.length > 0 && (
+        <>
+          <Grid>
+            {filteredData.map(renderCard)}
+          </Grid>
+          <LoadMoreContainer>
+            <Button variant="secondary" size="lg">더보기</Button>
+          </LoadMoreContainer>
+        </>
+      )}
+
+      {!isLoading && !isError && filteredData.length === 0 && (
+        <EmptyStateContainer>
+          <p>표시할 콘텐츠가 없습니다.</p>
+        </EmptyStateContainer>
+      )}
     </SectionWrapper>
   );
 };

--- a/src/components/pages/NewsEventsPage/index.tsx
+++ b/src/components/pages/NewsEventsPage/index.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import MainLayout from '../../templates/MainLayout';
+import ContentGrid from '../../organisms/ContentGrid';
 
 const NewsEventsPage = () => {
   return (
     <MainLayout>
-      <div style={{ padding: '2rem' }}>
-        <h1>바이오 뉴스/행사</h1>
-        <p>페이지가 준비중입니다.</p>
-      </div>
+      <ContentGrid />
     </MainLayout>
   );
 };

--- a/src/hooks/useNewsAndEvents.ts
+++ b/src/hooks/useNewsAndEvents.ts
@@ -1,0 +1,27 @@
+import useSWR from 'swr';
+import { ContentItem, News, Event } from '../types/api';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useNewsAndEvents() {
+  const { data: newsData, error: newsError } = useSWR<News[]>('/api/news', fetcher);
+  const { data: eventsData, error: eventsError } = useSWR<Event[]>('/api/events', fetcher);
+
+  const data = newsData && eventsData ? [...newsData, ...eventsData] : undefined;
+  const error = newsError || eventsError;
+
+  // Sort data by date (newest first)
+  if (data) {
+    data.sort((a, b) => {
+      const dateA = new Date('created_at' in a ? a.created_at : a.eventStartAt);
+      const dateB = new Date('created_at' in b ? b.created_at : b.eventStartAt);
+      return dateB.getTime() - dateA.getTime();
+    });
+  }
+
+  return {
+    data: data as ContentItem[] | undefined,
+    isLoading: !error && !data,
+    isError: error,
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,22 +1,27 @@
-export interface ApiAnnouncement {
+export interface News {
   id: number;
   title: string;
-  author: string; // Based on item.author usage
-  [key: string]: any; // Allow other properties
+  summary?: string;
+  content: string;
+  category: 'news' | 'notice';
+  created_at: string; // ISO 8601 date string
+  sourceName?: string;
+  thumbnailUrl?: string;
 }
 
-export interface ApiNews {
+export interface Event {
   id: number;
-  title:string;
-  category: string;
-  created_at: string; // Based on new Date(item.created_at)
-  [key: string]: any; // Allow other properties
+  title: string;
+  summary?: string;
+  thumbnailUrl?: string;
+  category: 'event';
+  eventStartAt: string; // ISO 8601 date string
+  eventEndAt: string; // ISO 8601 date string
+  locationType: 'online' | 'offline' | 'hybrid';
+  locationName?: string;
+  host: string;
+  registerDeadline?: string; // ISO 8601 date string
+  status: '예정' | '진행중' | '마감';
 }
 
-export interface ApiStat {
-  label: string;
-  value: string;
-  change: string;
-  icon: string;
-  [key: string]: any;
-}
+export type ContentItem = News | Event;


### PR DESCRIPTION
This commit completely overhauls the News & Events page, transforming it from a placeholder into a dynamic and feature-rich section.

Backend:
- Adds a new `Event` data model and corresponding mock data.
- Creates `/api/events` endpoints to serve event information.
- Enhances the `News` model with additional fields like `thumbnailUrl` and `sourceName` to support a richer UI.

Frontend:
- Implements a new `useNewsAndEvents` hook for fetching, combining, and sorting news and event data.
- Overhauls the `ContentGrid` component to be fully data-driven, with support for filtering via tabs (All, News, Event, Notice).
- Redesigns and unifies `NewsCard` and `EventCard` components to match the new design system, ensuring a consistent and responsive user experience.
- Implements a responsive grid layout that adapts from a single column on mobile to three columns on desktop.
- Adds key UI elements requested, including status badges for events, improved typography, hover effects, and a "Load More" button.