### PR TITLE
fix: Update Redoc CDN to a stable version

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -19,6 +19,6 @@
   </head>
   <body>
     <redoc spec-url='openapi.yml'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
The previous CDN link pointed to a '@next' version which was causing rendering issues with the OpenAPI spec. This commit updates the URL to point to the latest stable release of Redoc, which should resolve the parsing error.