### PR TITLE
feat: Implement mock backend API and Redoc documentation

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -7,6 +7,14 @@ from ..models.consultation import Consultation
 from ..models.user import UserInDB
 from ..models.service import Service
 from ..models.stat import Stat
+from ..models.support_program import SupportProgram, SupportProgramStatus
+from ..models.incubation_center import IncubationCenter, Location
+from ..models.technology import Technology
+from ..models.education import EducationProgram, EducationContent, EducationProgramStatus, EducationContentType
+from ..models.mentor import Mentor
+from ..models.search import SitemapNode
+from ..models.application import Application, ApplicationStatus
+from ..models.auth import RegistrationRequest
 
 # SQL Schema comments from the original request
 """
@@ -353,5 +361,441 @@ stats_db: list[Stat] = [
         change='+23',
         icon='trendingUp',
         color='#f97316'
+    )
+]
+
+# SQL Schema for Support Programs
+"""
+CREATE TABLE support_programs (
+    id VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    organization VARCHAR(255),
+    description TEXT,
+    start_date DATE,
+    end_date DATE,
+    status VARCHAR(50),
+    category VARCHAR(100),
+    support_type TEXT[],
+    target_company TEXT,
+    external_url VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+support_programs_db: list[SupportProgram] = [
+    SupportProgram(
+        id="sp_001",
+        title="2025년 중소기업 기술혁신 개발사업",
+        organization="중소벤처기업부",
+        description="중소기업의 기술 경쟁력 강화를 위한 R&D 자금 지원.",
+        startDate=date(2025, 3, 1),
+        endDate=date(2025, 9, 30),
+        status=SupportProgramStatus.ONGOING,
+        category="R&D",
+        supportType=["자금지원", "기술개발"],
+        targetCompany="창업 7년 이하, 매출 20억 미만 중소기업",
+        externalUrl="https://example.com/support/program1",
+        createdAt=datetime(2025, 2, 1, 9, 0, 0)
+    ),
+    SupportProgram(
+        id="sp_002",
+        title="바이오 분야 창업기업 육성 프로그램",
+        organization="한국생명공학연구원",
+        description="예비 창업자 및 초기 창업기업 대상 맞춤형 보육 및 멘토링 제공.",
+        startDate=date(2025, 4, 15),
+        endDate=date(2025, 10, 15),
+        status=SupportProgramStatus.ONGOING,
+        category="창업지원",
+        supportType=["멘토링", "공간지원", "네트워킹"],
+        targetCompany="예비 창업자 또는 3년 미만 창업기업",
+        externalUrl="https://example.com/support/program2",
+        createdAt=datetime(2025, 3, 10, 10, 0, 0)
+    ),
+    SupportProgram(
+        id="sp_003",
+        title="해외시장 진출 지원사업",
+        organization="KOTRA",
+        description="해외 바이어 매칭, 수출 상담회, 해외 전시회 참가 지원.",
+        startDate=date(2025, 1, 1),
+        endDate=date(2025, 12, 31),
+        status=SupportProgramStatus.UPCOMING,
+        category="수출지원",
+        supportType=["마케팅", "수출상담"],
+        targetCompany="수출 실적 500만불 미만 중소/중견기업",
+        externalUrl="https://example.com/support/program3",
+        createdAt=datetime(2024, 12, 15, 14, 0, 0)
+    ),
+    SupportProgram(
+        id="sp_004",
+        title="2024년 스마트공장 보급확산사업",
+        organization="스마트제조혁신추진단",
+        description="스마트공장 구축 및 고도화를 위한 비용 지원.",
+        startDate=date(2024, 5, 1),
+        endDate=date(2024, 11, 30),
+        status=SupportProgramStatus.CLOSED,
+        category="제조혁신",
+        supportType=["자금지원", "컨설팅"],
+        targetCompany="국내 중소/중견 제조기업",
+        externalUrl="https://example.com/support/program4",
+        createdAt=datetime(2024, 4, 5, 9, 0, 0)
+    ),
+]
+
+# SQL Schema for Incubation Centers
+"""
+CREATE TABLE incubation_centers (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    total_rooms INT,
+    vacant_rooms INT,
+    occupancy_rate FLOAT,
+    address VARCHAR(255),
+    contact VARCHAR(255),
+    manager VARCHAR(255),
+    latitude DECIMAL(9, 6),
+    longitude DECIMAL(9, 6)
+);
+"""
+
+incubation_centers_db: list[IncubationCenter] = [
+    IncubationCenter(
+        id="ic_001",
+        name="전북대학교 창업보육센터",
+        totalRooms=50,
+        vacantRooms=5,
+        occupancyRate=0.90,
+        address="전라북도 전주시 덕진구 백제대로 567",
+        contact="063-270-1234",
+        manager="김철수 센터장",
+        location=Location(latitude=35.8464, longitude=127.1293)
+    ),
+    IncubationCenter(
+        id="ic_002",
+        name="원광대학교 창업보육센터",
+        totalRooms=40,
+        vacantRooms=0,
+        occupancyRate=1.0,
+        address="전라북도 익산시 익산대로 460",
+        contact="063-850-5678",
+        manager="박영희 매니저",
+        location=Location(latitude=35.9687, longitude=126.9575)
+    ),
+    IncubationCenter(
+        id="ic_003",
+        name="전주정보문화산업진흥원 (JICA)",
+        totalRooms=30,
+        vacantRooms=8,
+        occupancyRate=0.73,
+        address="전라북도 전주시 완산구 아중로 225",
+        contact="063-281-4114",
+        manager="이진아 팀장",
+        location=Location(latitude=35.8227, longitude=127.1643)
+    ),
+]
+
+# SQL Schema for Technologies
+"""
+CREATE TABLE technologies (
+    id VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    summary TEXT,
+    organization VARCHAR(255),
+    patent_number VARCHAR(100),
+    application_date DATE,
+    category VARCHAR(100),
+    transferable BOOLEAN,
+    thumbnail_url VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+technologies_db: list[Technology] = [
+    Technology(
+        id="tech_001",
+        title="고효율 미생물 연료전지 개발",
+        summary="폐수를 활용하여 전기를 생산하는 친환경 고효율 미생물 연료전지 기술. 기존 기술 대비 전력 생산 효율 30% 향상.",
+        organization="전북대학교 신재생에너지연구소",
+        patentNumber="10-2024-0123456",
+        applicationDate=date(2024, 8, 1),
+        category="환경/에너지",
+        transferable=True,
+        thumbnail="https://picsum.photos/seed/tech1/400/300",
+        createdAt=datetime(2024, 9, 15, 10, 0, 0)
+    ),
+    Technology(
+        id="tech_002",
+        title="AI 기반 암 진단 보조 소프트웨어",
+        summary="의료 영상을 AI로 분석하여 초기 단계의 암을 95% 정확도로 판별하는 진단 보조 소프트웨어.",
+        organization="(주)메디컬AI",
+        patentNumber="10-2025-0011223",
+        applicationDate=date(2025, 1, 20),
+        category="의료/헬스케어",
+        transferable=True,
+        thumbnail="https://picsum.photos/seed/tech2/400/300",
+        createdAt=datetime(2025, 2, 28, 14, 30, 0)
+    ),
+    Technology(
+        id="tech_003",
+        title="스마트팜용 복합 환경제어 시스템",
+        summary="온도, 습도, CO2 농도, 광량 등을 통합 제어하여 작물 생산성을 극대화하는 IoT 기반 스마트팜 솔루션.",
+        organization="농업기술실용화재단",
+        patentNumber=None,
+        applicationDate=None,
+        category="농생명",
+        transferable=False,
+        thumbnail="https://picsum.photos/seed/tech3/400/300",
+        createdAt=datetime(2025, 5, 10, 11, 0, 0)
+    ),
+    Technology(
+        id="tech_004",
+        title="식물성 대체육 제조 기술",
+        summary="콩 단백질을 이용하여 실제 고기의 식감과 풍미를 재현한 식물성 대체육 제조 기술.",
+        organization="익산 국가식품클러스터",
+        patentNumber="10-2023-0987654",
+        applicationDate=date(2023, 11, 5),
+        category="식품/바이오",
+        transferable=True,
+        thumbnail="https://picsum.photos/seed/tech4/400/300",
+        createdAt=datetime(2024, 1, 15, 9, 0, 0)
+    ),
+]
+
+# SQL Schema for Education Programs
+"""
+CREATE TABLE education_programs (
+    id VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    organization VARCHAR(255),
+    category VARCHAR(100),
+    start_date DATE,
+    end_date DATE,
+    location VARCHAR(255),
+    cost FLOAT,
+    status VARCHAR(50),
+    target_audience VARCHAR(255),
+    application_url VARCHAR(255)
+);
+
+CREATE TABLE education_contents (
+    id VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    category VARCHAR(100),
+    type VARCHAR(50),
+    url VARCHAR(255),
+    thumbnail_url VARCHAR(255),
+    view_count INT DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+education_programs_db: list[EducationProgram] = [
+    EducationProgram(
+        id="edu_p_001",
+        title="바이오 전문인력 양성과정",
+        organization="전북바이오융합산업진흥원",
+        category="전문인력양성",
+        startDate=date(2025, 9, 1),
+        endDate=date(2025, 11, 30),
+        location="전북바이오융합산업진흥원 교육장",
+        cost=0.0,
+        status=EducationProgramStatus.UPCOMING,
+        targetAudience="바이오 분야 취업 희망자 및 재직자",
+        applicationUrl="https://example.com/edu/program1"
+    ),
+    EducationProgram(
+        id="edu_p_002",
+        title="GMP(우수 의약품 제조 및 품질관리 기준) 실무 과정",
+        organization="한국제약바이오협회",
+        category="품질관리",
+        startDate=date(2025, 7, 15),
+        endDate=date(2025, 7, 17),
+        location="온라인 (Zoom)",
+        cost=300000.0,
+        status=EducationProgramStatus.ONGOING,
+        targetAudience="제약/바이오 기업 품질관리/보증 담당자",
+        applicationUrl="https://example.com/edu/program2"
+    ),
+]
+
+education_contents_db: list[EducationContent] = [
+    EducationContent(
+        id="edu_c_001",
+        title="[영상] CRISPR-Cas9 유전자 가위 기술의 원리",
+        description="노벨상을 수상한 3세대 유전자 가위 기술, CRISPR-Cas9의 작동 원리를 쉽게 설명합니다.",
+        category="유전공학",
+        type=EducationContentType.VIDEO,
+        url="https://youtube.com/watch?v=example1",
+        thumbnail="https://picsum.photos/seed/content1/400/225",
+        viewCount=12048,
+        createdAt=datetime(2024, 10, 5, 10, 0, 0)
+    ),
+    EducationContent(
+        id="edu_c_002",
+        title="[PDF] 국내 바이오산업 특허 출원 동향 보고서",
+        description="2024년 상반기 국내 바이오산업의 특허 출원 동향 및 기술 트렌드 분석 자료입니다.",
+        category="기술동향",
+        type=EducationContentType.PDF,
+        url="https://example.com/report.pdf",
+        thumbnail="https://picsum.photos/seed/content2/400/225",
+        viewCount=5890,
+        createdAt=datetime(2024, 7, 28, 15, 30, 0)
+    ),
+]
+
+# SQL Schema for Mentors
+"""
+CREATE TABLE mentors (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    organization VARCHAR(255),
+    field TEXT[],
+    expertise TEXT,
+    experience TEXT,
+    available BOOLEAN,
+    contact_email VARCHAR(255),
+    external_url VARCHAR(255)
+);
+"""
+
+mentors_db: list[Mentor] = [
+    Mentor(
+        id="mentor_001",
+        name="김민준",
+        organization="전북창조경제혁신센터",
+        field=["사업화", "투자유치"],
+        expertise="초기 스타트업 비즈니스 모델 수립 및 IR 피칭 전문가. 다수의 스타트업을 성공적으로 엑셀러레이팅한 경험 보유.",
+        experience="창업기획자(액셀러레이터) 경력 10년, 50개 이상 기업 멘토링",
+        available=True,
+        contactEmail="minjun.kim@ccei.or.kr",
+        externalUrl="https://ccei.creativekorea.or.kr/jeonbuk/"
+    ),
+    Mentor(
+        id="mentor_002",
+        name="이서연",
+        organization="특허법인 A&P",
+        field=["특허", "법률"],
+        expertise="바이오 분야 기술 특허 출원 및 분쟁 해결 전문 변리사. 국내외 특허 전략 수립 컨설팅 제공.",
+        experience="변리사 경력 8년, 바이오 분야 특허 200건 이상 출원",
+        available=True,
+        contactEmail="seoyeon.lee@ap-patent.com",
+        externalUrl=None
+    ),
+    Mentor(
+        id="mentor_003",
+        name="박지훈",
+        organization="한국생명공학연구원",
+        field=["기술개발", "R&D"],
+        expertise="유전자 편집 기술 및 세포 치료제 연구 개발 전문가. 국가 R&D 과제 다수 수행.",
+        experience="선임연구원 경력 15년, SCI급 논문 30편 이상",
+        available=False,
+        contactEmail="jihun.park@kribb.re.kr",
+        externalUrl=None
+    ),
+]
+
+# SQL Schema for Sitemap (usually generated dynamically, but here for structure)
+"""
+CREATE TABLE sitemap_nodes (
+    id SERIAL PRIMARY KEY,
+    parent_id INTEGER REFERENCES sitemap_nodes(id),
+    title VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    "order" INT
+);
+"""
+
+sitemap_db: list[SitemapNode] = [
+    SitemapNode(title="홈", url="/", children=[]),
+    SitemapNode(
+        title="기업지원",
+        url="/support",
+        children=[
+            SitemapNode(title="지원사업", url="/support-programs", children=[]),
+            SitemapNode(title="창업보육센터", url="/incubation-centers", children=[]),
+        ]
+    ),
+    SitemapNode(
+        title="기술정보",
+        url="/tech",
+        children=[
+            SitemapNode(title="기술 및 특허", url="/tech-summary/list", children=[]),
+        ]
+    ),
+    SitemapNode(
+        title="교육 및 인력",
+        url="/education",
+        children=[
+            SitemapNode(title="교육 프로그램", url="/programs", children=[]),
+            SitemapNode(title="교육 콘텐츠", url="/education/contents", children=[]),
+            SitemapNode(title="전문가 멘토링", url="/mentors", children=[]),
+        ]
+    ),
+    SitemapNode(title="기업DB", url="/companies", children=[]),
+    SitemapNode(title="알림마당", url="/notices", children=[]),
+]
+
+# SQL Schema for Applications
+"""
+CREATE TABLE applications (
+    id VARCHAR(255) PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    program_id VARCHAR(255) REFERENCES support_programs(id),
+    program_title VARCHAR(255),
+    status VARCHAR(50),
+    applied_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    reviewed_at TIMESTAMP WITH TIME ZONE,
+    review_comment TEXT
+);
+"""
+
+applications_db: list[Application] = [
+    Application(
+        id="app_001",
+        programId="sp_001",
+        programTitle="2025년 중소기업 기술혁신 개발사업",
+        status=ApplicationStatus.PENDING,
+        appliedAt=datetime(2025, 3, 5, 10, 30, 0),
+    ),
+    Application(
+        id="app_002",
+        programId="sp_002",
+        programTitle="바이오 분야 창업기업 육성 프로그램",
+        status=ApplicationStatus.APPROVED,
+        appliedAt=datetime(2025, 4, 20, 15, 0, 0),
+        reviewedAt=datetime(2025, 4, 22, 11, 0, 0),
+        reviewComment="서류 심사 통과. 대면 심사 예정."
+    ),
+]
+
+# SQL Schema for Registration Requests
+"""
+CREATE TABLE registration_requests (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    organization VARCHAR(255),
+    requested_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    status VARCHAR(50) DEFAULT 'pending'
+);
+"""
+
+registration_requests_db: list[RegistrationRequest] = [
+    RegistrationRequest(
+        userId="user_req_1",
+        name="김신청",
+        email="newuser1@example.com",
+        organization="미래 바이오",
+        requestedAt=datetime(2025, 8, 17, 11, 0, 0),
+        status="pending"
+    ),
+    RegistrationRequest(
+        userId="user_req_2",
+        name="박대기",
+        email="newuser2@example.com",
+        organization="헬스케어 스타트업",
+        requestedAt=datetime(2025, 8, 16, 18, 30, 0),
+        status="pending"
     )
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
 
 # --- API Routers ---
 # Routers for each domain will be included here to modularize the application.
-from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster
+from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster, support_program, incubation_center, technology, education, mentor, search, auth
 
 app.include_router(announcement.router, prefix="/api")
 app.include_router(company.router, prefix="/api")
@@ -30,6 +30,13 @@ app.include_router(admin.router, prefix="/api")
 app.include_router(service.router, prefix="/api")
 app.include_router(stat.router, prefix="/api")
 app.include_router(cluster.router, prefix="/api")
+app.include_router(support_program.router, prefix="/api")
+app.include_router(incubation_center.router, prefix="/api")
+app.include_router(technology.router, prefix="/api")
+app.include_router(education.router, prefix="/api")
+app.include_router(mentor.router, prefix="/api")
+app.include_router(search.router, prefix="/api")
+app.include_router(auth.router, prefix="/api")
 # ...
 
 

--- a/backend/models/admin.py
+++ b/backend/models/admin.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from typing import List, Dict
+
+
+class Admin(BaseModel):
+    id: str
+    username: str
+    role: str  # In a real app, use Enum: [admin, super_admin]
+    permissions: List[str]
+
+
+class SystemStats(BaseModel):
+    dailyLogins: int
+    monthlyTraffic: int
+
+
+class DashboardSummary(BaseModel):
+    userCount: int
+    activeUsers: int
+    pendingApprovals: int
+    announcementCount: int
+    systemStats: SystemStats

--- a/backend/models/application.py
+++ b/backend/models/application.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+from enum import Enum
+
+
+class ApplicationStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    COMPLETED = "completed"
+
+
+class Application(BaseModel):
+    id: str
+    programId: str
+    programTitle: str
+    status: ApplicationStatus
+    appliedAt: datetime
+    reviewedAt: Optional[datetime] = None
+    reviewComment: Optional[str] = None

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, EmailStr
+from typing import List, Optional
+from datetime import datetime
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+    rememberMe: bool = False
+
+
+class RegisterRequest(BaseModel):
+    name: str
+    email: EmailStr
+    password: str
+    organization: str
+    phone: Optional[str] = None
+    agreedToTerms: bool
+    agreedToPrivacy: bool
+
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class PasswordResetVerify(BaseModel):
+    token: str
+    newPassword: str
+
+
+class RegistrationRequest(BaseModel):
+    userId: str
+    name: str
+    email: EmailStr
+    organization: str
+    requestedAt: datetime
+    status: str  # enum: [pending, approved, rejected]

--- a/backend/models/education.py
+++ b/backend/models/education.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import date, datetime
+from enum import Enum
+
+
+class EducationProgramStatus(str, Enum):
+    UPCOMING = "upcoming"
+    ONGOING = "ongoing"
+    CLOSED = "closed"
+
+
+class EducationProgram(BaseModel):
+    id: str
+    title: str
+    organization: str
+    category: str
+    startDate: date
+    endDate: date
+    location: str
+    cost: float
+    status: EducationProgramStatus
+    targetAudience: str
+    applicationUrl: Optional[str] = None
+
+
+class EducationContentType(str, Enum):
+    VIDEO = "video"
+    PDF = "pdf"
+    DOCUMENT = "document"
+
+
+class EducationContent(BaseModel):
+    id: str
+    title: str
+    description: str
+    category: str
+    type: EducationContentType
+    url: str
+    thumbnail: Optional[str] = None
+    viewCount: int
+    createdAt: datetime

--- a/backend/models/incubation_center.py
+++ b/backend/models/incubation_center.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Location(BaseModel):
+    latitude: float
+    longitude: float
+
+
+class IncubationCenter(BaseModel):
+    id: str
+    name: str
+    totalRooms: int
+    vacantRooms: int
+    occupancyRate: float
+    address: str
+    contact: Optional[str] = None
+    manager: Optional[str] = None
+    location: Location

--- a/backend/models/mentor.py
+++ b/backend/models/mentor.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional, List
+
+
+class Mentor(BaseModel):
+    id: str
+    name: str
+    organization: str
+    field: List[str]
+    expertise: str
+    experience: str
+    available: bool
+    contactEmail: Optional[EmailStr] = None
+    externalUrl: Optional[str] = None

--- a/backend/models/search.py
+++ b/backend/models/search.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from typing import Optional, List
+
+from .support_program import Pagination  # Re-use existing Pagination model
+
+
+class SearchResult(BaseModel):
+    id: str
+    type: str
+    title: str
+    description: str
+    url: str
+    relevanceScore: float
+
+
+class PaginatedSearchResponse(BaseModel):
+    results: List[SearchResult]
+    pagination: Pagination
+
+
+class SitemapNode(BaseModel):
+    title: str
+    url: str
+    children: Optional[List['SitemapNode']] = None
+
+
+# This is needed for Pydantic to handle the forward reference in the recursive model
+SitemapNode.model_rebuild()

--- a/backend/models/support_program.py
+++ b/backend/models/support_program.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, HttpUrl
+from typing import List, Optional
+from datetime import date, datetime
+from enum import Enum
+
+
+class SupportProgramStatus(str, Enum):
+    UPCOMING = "upcoming"
+    ONGOING = "ongoing"
+    CLOSED = "closed"
+
+
+class SupportProgram(BaseModel):
+    id: str
+    title: str
+    organization: str
+    description: str
+    startDate: date
+    endDate: date
+    status: SupportProgramStatus
+    category: str
+    supportType: List[str]
+    targetCompany: str
+    externalUrl: Optional[str] = None  # Using str for now, can be HttpUrl for validation
+    createdAt: datetime
+
+
+class Pagination(BaseModel):
+    page: int
+    limit: int
+    total: int
+    totalPages: int
+    hasNext: bool
+    hasPrev: bool
+
+
+class PaginatedSupportProgramResponse(BaseModel):
+    data: List[SupportProgram]
+    pagination: Pagination

--- a/backend/models/technology.py
+++ b/backend/models/technology.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import date, datetime
+
+from .support_program import Pagination
+
+
+class Technology(BaseModel):
+    id: str
+    title: str
+    summary: str
+    organization: str
+    patentNumber: Optional[str] = None
+    applicationDate: Optional[date] = None
+    category: str
+    transferable: bool
+    thumbnail: Optional[str] = None
+    createdAt: datetime
+
+
+class PaginatedTechnologyResponse(BaseModel):
+    data: List[Technology]
+    pagination: Pagination

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,24 +1,122 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-from typing import List
+from fastapi import APIRouter, HTTPException, status, Depends, Body
+from typing import List, Optional
+import uuid
 
 from ..models.announcement import Announcement, AnnouncementCreate
-from ..db.mock_data import announcements_db
-from .user import get_current_user, User
+from ..models.user import User
+from ..models.auth import RegistrationRequest
+from ..models.admin import Admin, DashboardSummary
+from ..db.mock_data import announcements_db, users_db, registration_requests_db
+from .user import get_current_user
 
 router = APIRouter(
     prefix="/admin",
     tags=["Admin"],
-    dependencies=[Depends(get_current_user)] # Protect all admin routes
+    # The dependency below protects all routes in this file
+    dependencies=[Depends(get_current_user)]
 )
 
-def check_admin(current_user: User):
-    if current_user.role != 'admin':
+
+def check_admin_role(current_user: User = Depends(get_current_user)):
+    """Dependency to check if the current user is an admin."""
+    user_in_db = next((u for u in users_db if u.id == current_user.id), None)
+    if not user_in_db or user_in_db.role != 'admin':
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required"
         )
 
-@router.post("/announcements", response_model=Announcement, dependencies=[Depends(check_admin)])
+
+# Note: The /admin/auth/login is defined in openapi.yml but a generic /auth/login already exists.
+# An admin would log in via the same endpoint and receive a token based on their role.
+# A separate admin login endpoint is redundant if roles are handled correctly.
+# For now, we will implement the other admin endpoints which are protected by role checks.
+
+@router.get("/dashboard/summary", response_model=DashboardSummary, dependencies=[Depends(check_admin_role)])
+def get_dashboard_summary():
+    """Get a summary of dashboard metrics."""
+    active_users = len([u for u in users_db if u.role != 'inactive'])
+    pending_approvals = len([r for r in registration_requests_db if r.status == 'pending'])
+
+    return DashboardSummary(
+        userCount=len(users_db),
+        activeUsers=active_users,
+        pendingApprovals=pending_approvals,
+        announcementCount=len(announcements_db),
+        systemStats={"dailyLogins": 120, "monthlyTraffic": 15000} # Mocked stats
+    )
+
+@router.get("/users", response_model=List[User], dependencies=[Depends(check_admin_role)])
+def get_all_users(status: Optional[str] = None, search: Optional[str] = None):
+    """Get a list of all users, with optional filters."""
+    results = [User(**u.model_dump(exclude={'password'})) for u in users_db]
+    if status:
+        # This is a mock filter. A real app might have a proper status field.
+        pass # Not implemented in mock data
+    if search:
+        results = [u for u in results if search.lower() in u.username.lower() or search.lower() in u.email.lower()]
+    return results
+
+@router.patch("/users/{user_id}/status", dependencies=[Depends(check_admin_role)])
+def update_user_status(user_id: int, status_update: dict = Body(...)):
+    """Update a user's status."""
+    user = next((u for u in users_db if u.id == user_id), None)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    # In a real app, you'd update a status field. We'll mock this by changing role.
+    new_status = status_update.get("status")
+    if new_status not in ["active", "inactive"]:
+        raise HTTPException(status_code=400, detail="Invalid status")
+    # user.status = new_status # Assuming a status field exists on the model
+    return {"message": f"User {user_id} status updated to {new_status}"}
+
+@router.patch("/users/{user_id}/role", dependencies=[Depends(check_admin_role)])
+def update_user_role(user_id: int, role_update: dict = Body(...)):
+    """Update a user's role."""
+    user = next((u for u in users_db if u.id == user_id), None)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    new_role = role_update.get("role")
+    if new_role not in ["user", "admin", "manager"]:
+        raise HTTPException(status_code=400, detail="Invalid role")
+    user.role = new_role
+    return {"message": f"User {user_id} role updated to {new_role}"}
+
+@router.get("/users/registration-requests", response_model=List[RegistrationRequest], dependencies=[Depends(check_admin_role)])
+def get_registration_requests():
+    """Get the list of pending registration requests."""
+    return [r for r in registration_requests_db if r.status == 'pending']
+
+@router.post("/users/registration-requests/approve", dependencies=[Depends(check_admin_role)])
+def approve_registration(approval: dict = Body(...)):
+    """Approve a registration request."""
+    user_id_to_approve = approval.get("userIds", [])[0] # Mock: approve one at a time
+    req = next((r for r in registration_requests_db if r.userId == user_id_to_approve), None)
+    if not req or req.status != 'pending':
+        raise HTTPException(status_code=404, detail="Request not found or not pending")
+    req.status = "approved"
+    # Create a new user
+    new_user_id = max(u.id for u in users_db) + 1 if users_db else 1
+    # Note: A real implementation would require a password to be set.
+    # We will mock a user with a default password.
+    new_user = User(id=new_user_id, username=req.name, email=req.email, full_name=req.name, role='user')
+    users_db.append(new_user)
+    return {"message": f"User registration for {req.email} approved."}
+
+@router.post("/users/registration-requests/reject", dependencies=[Depends(check_admin_role)])
+def reject_registration(rejection: dict = Body(...)):
+    """Reject a registration request."""
+    user_id_to_reject = rejection.get("userId")
+    req = next((r for r in registration_requests_db if r.userId == user_id_to_reject), None)
+    if not req or req.status != 'pending':
+        raise HTTPException(status_code=404, detail="Request not found or not pending")
+    req.status = "rejected"
+    return {"message": f"User registration for {req.email} rejected."}
+
+
+# --- Existing Announcement Management ---
+
+@router.post("/announcements", response_model=Announcement, dependencies=[Depends(check_admin_role)])
 def create_announcement(announcement: AnnouncementCreate):
     """
     UI-99-02: Create a new announcement.
@@ -28,7 +126,7 @@ def create_announcement(announcement: AnnouncementCreate):
     announcements_db.append(new_announcement)
     return new_announcement
 
-@router.put("/announcements/{announcement_id}", response_model=Announcement, dependencies=[Depends(check_admin)])
+@router.put("/announcements/{announcement_id}", response_model=Announcement, dependencies=[Depends(check_admin_role)])
 def update_announcement(announcement_id: int, announcement_update: AnnouncementCreate):
     """
     UI-99-02: Update an existing announcement.
@@ -43,7 +141,7 @@ def update_announcement(announcement_id: int, announcement_update: AnnouncementC
     announcements_db[index] = updated_announcement
     return updated_announcement
 
-@router.delete("/announcements/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(check_admin)])
+@router.delete("/announcements/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(check_admin_role)])
 def delete_announcement(announcement_id: int):
     """
     UI-99-02: Delete an announcement.

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from typing import Annotated
+import uuid
+from datetime import datetime
+
+from ..models.user import User, Token
+from ..models.auth import LoginRequest, RegisterRequest, PasswordResetRequest, PasswordResetVerify, RegistrationRequest
+from ..db.mock_data import users_db, registration_requests_db
+
+router = APIRouter(
+    tags=["Auth"]
+)
+
+
+def get_user_by_email(email: str):
+    user = next((user for user in users_db if user.email == email), None)
+    return user
+
+
+@router.post("/auth/login", response_model=Token)
+def login_for_access_token(form_data: LoginRequest):
+    """
+    Logs in a user and returns an access token.
+    """
+    user = get_user_by_email(form_data.email)
+    if not user or user.password != form_data.password:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # In a real app, you'd create a real JWT token here.
+    access_token = f"fake-jwt-token-for-user-{user.id}"
+
+    # Exclude password from the returned user object
+    user_data = User(**user.model_dump(exclude={'password'}))
+
+    return Token(access_token=access_token, token_type="bearer", user=user_data)
+
+
+@router.post("/auth/register", status_code=status.HTTP_201_CREATED)
+def register_user(form_data: RegisterRequest):
+    """
+    Handles a new user registration request.
+    This mock implementation adds the request to a queue for admin approval.
+    """
+    if get_user_by_email(form_data.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    new_request = RegistrationRequest(
+        userId=f"user_req_{uuid.uuid4()}",
+        name=form_data.name,
+        email=form_data.email,
+        organization=form_data.organization,
+        requestedAt=datetime.now(),
+        status="pending"
+    )
+    registration_requests_db.append(new_request)
+
+    return {"status": "pending", "message": "가입 요청이 접수되었습니다. 관리자의 승인을 기다려주세요."}
+
+
+@router.post("/auth/password-reset/request")
+def request_password_reset(form_data: PasswordResetRequest):
+    """
+    Initiates a password reset request.
+    In a real app, this would send a reset link/code to the user's email.
+    """
+    # Check if user exists
+    if not get_user_by_email(form_data.email):
+        # Still return a success message to prevent user enumeration attacks
+        return {"message": "인증 코드 발송 완료"}
+
+    # Mock response
+    return {"message": "인증 코드 발송 완료"}
+
+
+@router.post("/auth/password-reset/verify")
+def verify_password_reset(form_data: PasswordResetVerify):
+    """
+    Verifies the password reset token and sets a new password.
+    """
+    # Mock response
+    print(f"Password reset for token {form_data.token} with new password {form_data.newPassword}")
+    return {"message": "비밀번호 재설정 완료"}

--- a/backend/routers/education.py
+++ b/backend/routers/education.py
@@ -1,0 +1,83 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
+
+from ..models.education import EducationProgram, EducationContent, EducationProgramStatus, EducationContentType
+from ..db.mock_data import education_programs_db, education_contents_db
+
+router = APIRouter(
+    tags=["Education"]
+)
+
+
+@router.get("/programs", response_model=List[EducationProgram])
+def get_education_programs(
+    category: Optional[str] = Query(None, description="Filter by category"),
+    organization: Optional[str] = Query(None, description="Filter by organization"),
+    status: Optional[EducationProgramStatus] = Query(None, description="Filter by program status"),
+    month: Optional[str] = Query(None, description="Filter by month in YYYY-MM format"),
+    keyword: Optional[str] = Query(None, description="Search keyword in title"),
+):
+    """
+    Get a list of education programs with filtering.
+    """
+    filtered_programs = education_programs_db
+
+    if category:
+        filtered_programs = [p for p in filtered_programs if category.lower() in p.category.lower()]
+    if organization:
+        filtered_programs = [p for p in filtered_programs if organization.lower() in p.organization.lower()]
+    if status:
+        filtered_programs = [p for p in filtered_programs if p.status == status]
+    if month:
+        try:
+            year, mon = map(int, month.split('-'))
+            filtered_programs = [p for p in filtered_programs if p.startDate.year == year and p.startDate.month == mon]
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid month format. Use YYYY-MM.")
+    if keyword:
+        filtered_programs = [p for p in filtered_programs if keyword.lower() in p.title.lower()]
+
+    return filtered_programs
+
+
+@router.get("/programs/{program_id}", response_model=EducationProgram)
+def get_education_program(program_id: str):
+    """
+    Get details of a specific education program by its ID.
+    """
+    program = next((p for p in education_programs_db if p.id == program_id), None)
+    if not program:
+        raise HTTPException(status_code=404, detail="Education program not found")
+    return program
+
+
+@router.get("/education/contents", response_model=List[EducationContent])
+def get_education_contents(
+    category: Optional[str] = Query(None, description="Filter by category"),
+    type: Optional[EducationContentType] = Query(None, description="Filter by content type"),
+    keyword: Optional[str] = Query(None, description="Search keyword in title or description"),
+):
+    """
+    Get a list of education contents with filtering.
+    """
+    filtered_contents = education_contents_db
+
+    if category:
+        filtered_contents = [c for c in filtered_contents if category.lower() in c.category.lower()]
+    if type:
+        filtered_contents = [c for c in filtered_contents if c.type == type]
+    if keyword:
+        filtered_contents = [c for c in filtered_contents if keyword.lower() in c.title.lower() or keyword.lower() in c.description.lower()]
+
+    return filtered_contents
+
+
+@router.get("/education/contents/{content_id}", response_model=EducationContent)
+def get_education_content(content_id: str):
+    """
+    Get details of a specific education content by its ID.
+    """
+    content = next((c for c in education_contents_db if c.id == content_id), None)
+    if not content:
+        raise HTTPException(status_code=404, detail="Education content not found")
+    return content

--- a/backend/routers/incubation_center.py
+++ b/backend/routers/incubation_center.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
+
+from ..models.incubation_center import IncubationCenter
+from ..db.mock_data import incubation_centers_db
+
+router = APIRouter(
+    tags=["Incubation Centers"]
+)
+
+@router.get("/incubation-centers", response_model=List[IncubationCenter])
+def get_incubation_centers(
+    hasVacancy: Optional[bool] = Query(None, description="Filter by centers that have vacant rooms"),
+    region: Optional[str] = Query(None, description="Filter by region (e.g., 전주시)"),
+    keyword: Optional[str] = Query(None, description="Search keyword in name or address"),
+):
+    """
+    Get a list of incubation centers with filtering.
+    """
+    filtered_centers = incubation_centers_db
+
+    if hasVacancy is not None:
+        if hasVacancy:
+            filtered_centers = [c for c in filtered_centers if c.vacantRooms > 0]
+        else:
+            filtered_centers = [c for c in filtered_centers if c.vacantRooms == 0]
+
+    if region:
+        # Case-insensitive search for region in address
+        filtered_centers = [c for c in filtered_centers if region.lower() in c.address.lower()]
+
+    if keyword:
+        # Case-insensitive search for keyword in name or address
+        filtered_centers = [c for c in filtered_centers if keyword.lower() in c.name.lower() or keyword.lower() in c.address.lower()]
+
+    return filtered_centers
+
+
+@router.get("/incubation-centers/{center_id}", response_model=IncubationCenter)
+def get_incubation_center(center_id: str):
+    """
+    Get details of a specific incubation center by its ID.
+    """
+    center = next((c for c in incubation_centers_db if c.id == center_id), None)
+    if not center:
+        raise HTTPException(status_code=404, detail="Incubation center not found")
+    return center

--- a/backend/routers/mentor.py
+++ b/backend/routers/mentor.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
+
+from ..models.mentor import Mentor
+from ..db.mock_data import mentors_db
+
+router = APIRouter(
+    tags=["Mentors"]
+)
+
+
+@router.get("/mentors", response_model=List[Mentor])
+def get_mentors(
+    field: Optional[str] = Query(None, description="Filter by mentor's field of expertise"),
+    available: Optional[bool] = Query(None, description="Filter by availability"),
+    keyword: Optional[str] = Query(None, description="Search keyword in name, organization, or expertise"),
+):
+    """
+    Get a list of mentors with filtering.
+    """
+    filtered_mentors = mentors_db
+
+    if field:
+        # Check if the field string is a substring of any field in the mentor's list
+        filtered_mentors = [m for m in filtered_mentors if any(field.lower() in f.lower() for f in m.field)]
+    if available is not None:
+        filtered_mentors = [m for m in filtered_mentors if m.available == available]
+    if keyword:
+        # Case-insensitive search
+        keyword_lower = keyword.lower()
+        filtered_mentors = [
+            m for m in filtered_mentors if
+            keyword_lower in m.name.lower() or
+            keyword_lower in m.organization.lower() or
+            keyword_lower in m.expertise.lower()
+        ]
+
+    return filtered_mentors
+
+
+@router.get("/mentors/{mentor_id}", response_model=Mentor)
+def get_mentor(mentor_id: str):
+    """
+    Get details of a specific mentor by their ID.
+    """
+    mentor = next((m for m in mentors_db if m.id == mentor_id), None)
+    if not mentor:
+        raise HTTPException(status_code=404, detail="Mentor not found")
+    return mentor

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter, Query
+from typing import List, Optional
+import math
+
+from ..models.search import SearchResult, PaginatedSearchResponse, SitemapNode
+from ..models.support_program import Pagination
+from ..db.mock_data import (
+    support_programs_db,
+    incubation_centers_db,
+    technologies_db,
+    companies_db,
+    announcements_db,
+    sitemap_db,
+)
+
+router = APIRouter(
+    tags=["Search"]
+)
+
+
+@router.get("/search", response_model=PaginatedSearchResponse)
+def search_all(
+    q: str = Query(..., description="Search query"),
+    type: Optional[str] = Query("all", enum=["all", "programs", "centers", "technologies", "companies", "notices"]),
+    sort: Optional[str] = Query("relevance", enum=["relevance", "date", "popularity"]),
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1),
+):
+    """
+    Perform a unified search across different data types.
+    """
+    all_results: List[SearchResult] = []
+    keyword = q.lower()
+
+    # Search logic for each type
+    if type == "all" or type == "programs":
+        for item in support_programs_db:
+            if keyword in item.title.lower() or keyword in item.description.lower():
+                all_results.append(SearchResult(
+                    id=item.id, type="program", title=item.title,
+                    description=item.description, url=f"/support-programs/{item.id}", relevanceScore=0.9
+                ))
+
+    if type == "all" or type == "centers":
+        for item in incubation_centers_db:
+            if keyword in item.name.lower() or keyword in item.address.lower():
+                all_results.append(SearchResult(
+                    id=item.id, type="center", title=item.name,
+                    description=item.address, url=f"/incubation-centers/{item.id}", relevanceScore=0.8
+                ))
+
+    if type == "all" or type == "technologies":
+        for item in technologies_db:
+            if keyword in item.title.lower() or keyword in item.summary.lower():
+                all_results.append(SearchResult(
+                    id=item.id, type="technology", title=item.title,
+                    description=item.summary, url=f"/tech-summary/detail/{item.id}", relevanceScore=0.85
+                ))
+
+    if type == "all" or type == "companies":
+        for item in companies_db:
+            if keyword in item.name.lower() or keyword in item.description.lower():
+                all_results.append(SearchResult(
+                    id=item.id, type="company", title=item.name,
+                    description=item.description, url=f"/companies/{item.id}", relevanceScore=0.7
+                ))
+
+    if type == "all" or type == "notices":
+        for item in announcements_db:
+            if keyword in item.title.lower() or keyword in item.content.lower():
+                all_results.append(SearchResult(
+                    id=str(item.id), type="notice", title=item.title,
+                    description=item.content, url=f"/notices/{item.id}", relevanceScore=0.75
+                ))
+
+    # Mock sorting
+    if sort == "relevance":
+        all_results.sort(key=lambda x: x.relevanceScore, reverse=True)
+    # In a real app, 'date' and 'popularity' would require actual data fields and logic
+
+    # Pagination
+    total_items = len(all_results)
+    start_index = (page - 1) * limit
+    end_index = start_index + limit
+    paginated_data = all_results[start_index:end_index]
+
+    total_pages = math.ceil(total_items / limit) if limit > 0 else 0
+
+    pagination_meta = Pagination(
+        page=page,
+        limit=limit,
+        total=total_items,
+        totalPages=total_pages,
+        hasNext=page < total_pages,
+        hasPrev=page > 1 and total_pages > 0,
+    )
+
+    return PaginatedSearchResponse(results=paginated_data, pagination=pagination_meta)
+
+
+@router.get("/sitemap", response_model=List[SitemapNode])
+def get_sitemap():
+    """
+    Get the sitemap structure.
+    """
+    return sitemap_db

--- a/backend/routers/support_program.py
+++ b/backend/routers/support_program.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
+import math
+
+from ..models.support_program import SupportProgram, PaginatedSupportProgramResponse, Pagination, SupportProgramStatus
+from ..db.mock_data import support_programs_db
+
+router = APIRouter(
+    tags=["Support Programs"]
+)
+
+@router.get("/support-programs", response_model=PaginatedSupportProgramResponse)
+def get_support_programs(
+    page: int = 1,
+    limit: int = 20,
+    status: Optional[SupportProgramStatus] = Query(None, description="Filter by program status"),
+    organization: Optional[str] = Query(None, description="Filter by organization name"),
+    keyword: Optional[str] = Query(None, description="Search keyword in title or description"),
+):
+    """
+    Get a list of support programs with pagination and filtering.
+    """
+    filtered_programs = support_programs_db
+
+    # Apply filters
+    if status:
+        filtered_programs = [p for p in filtered_programs if p.status == status]
+    if organization:
+        # Case-insensitive search
+        filtered_programs = [p for p in filtered_programs if organization.lower() in p.organization.lower()]
+    if keyword:
+        # Case-insensitive search
+        filtered_programs = [p for p in filtered_programs if keyword.lower() in p.title.lower() or keyword.lower() in p.description.lower()]
+
+    # Apply pagination
+    total_items = len(filtered_programs)
+    start_index = (page - 1) * limit
+    end_index = start_index + limit
+    paginated_data = filtered_programs[start_index:end_index]
+
+    total_pages = math.ceil(total_items / limit) if limit > 0 else 0
+
+    pagination_meta = Pagination(
+        page=page,
+        limit=limit,
+        total=total_items,
+        totalPages=total_pages,
+        hasNext=page < total_pages,
+        hasPrev=page > 1 and total_pages > 0,
+    )
+
+    return PaginatedSupportProgramResponse(data=paginated_data, pagination=pagination_meta)
+
+
+@router.get("/support-programs/{program_id}", response_model=SupportProgram)
+def get_support_program(program_id: str):
+    """
+    Get details of a specific support program by its ID.
+    """
+    program = next((p for p in support_programs_db if p.id == program_id), None)
+    if not program:
+        raise HTTPException(status_code=404, detail="Support program not found")
+    return program

--- a/backend/routers/technology.py
+++ b/backend/routers/technology.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+import math
+
+from ..models.technology import Technology, PaginatedTechnologyResponse
+from ..models.support_program import Pagination  # Reuse Pagination model
+from ..db.mock_data import technologies_db
+
+router = APIRouter(
+    tags=["Tech Summary"]
+)
+
+
+@router.get("/tech-summary/list", response_model=PaginatedTechnologyResponse)
+def get_technologies(
+    page: int = 1,
+    limit: int = 20,
+    keyword: Optional[str] = Query(None, description="Search keyword in title or summary"),
+    organization: Optional[str] = Query(None, description="Filter by organization name"),
+    category: Optional[str] = Query(None, description="Filter by category"),
+    transferable: Optional[bool] = Query(None, description="Filter by transferability"),
+):
+    """
+    Get a list of technologies and patents with pagination and filtering.
+    """
+    filtered_techs = technologies_db
+
+    # Apply filters
+    if keyword:
+        filtered_techs = [t for t in filtered_techs if keyword.lower() in t.title.lower() or keyword.lower() in t.summary.lower()]
+    if organization:
+        filtered_techs = [t for t in filtered_techs if organization.lower() in t.organization.lower()]
+    if category:
+        filtered_techs = [t for t in filtered_techs if category.lower() == t.category.lower()]
+    if transferable is not None:
+        filtered_techs = [t for t in filtered_techs if t.transferable == transferable]
+
+    # Apply pagination
+    total_items = len(filtered_techs)
+    start_index = (page - 1) * limit
+    end_index = start_index + limit
+    paginated_data = filtered_techs[start_index:end_index]
+
+    total_pages = math.ceil(total_items / limit) if limit > 0 else 0
+
+    pagination_meta = Pagination(
+        page=page,
+        limit=limit,
+        total=total_items,
+        totalPages=total_pages,
+        hasNext=page < total_pages,
+        hasPrev=page > 1 and total_pages > 0,
+    )
+
+    return PaginatedTechnologyResponse(data=paginated_data, pagination=pagination_meta)
+
+
+@router.get("/tech-summary/detail/{tech_id}", response_model=Technology)
+def get_technology(tech_id: str):
+    """
+    Get details of a specific technology by its ID.
+    """
+    tech = next((t for t in technologies_db if t.id == tech_id), None)
+    if not tech:
+        raise HTTPException(status_code=404, detail="Technology not found")
+    return tech

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,60 +1,111 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException, status, Body
+from fastapi.security import OAuth2PasswordBearer
+from typing import Annotated, List
 
-from ..models.user import User, Token
-from ..db.mock_data import users_db
+from ..models.user import User
+from ..models.application import Application
+from ..db.mock_data import users_db, applications_db
 
 router = APIRouter(
     tags=["Users"]
 )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
-
-def get_user(username: str):
-    user = next((user for user in users_db if user.username == username), None)
-    return user
-
-@router.post("/auth/token", response_model=Token)
-def login_for_access_token(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
-    """
-    UI-07-01: Login and get an access token.
-    """
-    user = get_user(form_data.username)
-    if not user or user.password != form_data.password:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    # In a real app, you'd create a real JWT token here.
-    access_token = f"fake-jwt-token-for-user-{user.id}"
-
-    # Exclude password from the returned user object
-    user_data = User(**user.model_dump(exclude={'password'}))
-
-    return Token(access_token=access_token, token_type="bearer", user=user_data)
+# The tokenUrl should point to the new login endpoint, which is in the auth router
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 
 
+# This is a mock dependency. In a real app, this would decode a JWT.
 async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
     """
     Dependency to get the current user from a token.
+    For mocking, we assume the token is the user's ID.
+    e.g., "fake-jwt-token-for-user-1"
     """
     if not token.startswith("fake-jwt-token-for-user-"):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token format")
 
-    user_id = int(token.replace("fake-jwt-token-for-user-", ""))
-    user = next((user for user in users_db if user.id == user_id), None)
-    if user is None:
+    try:
+        # Extract user ID from the fake token
+        user_id_str = token.replace("fake-jwt-token-for-user-", "")
+        user_id = int(user_id_str)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user ID in token")
+
+    user_in_db = next((u for u in users_db if u.id == user_id), None)
+    if user_in_db is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
-    return User(**user.model_dump(exclude={'password'}))
+    # Return the public User model, not UserInDB with password
+    return User(**user_in_db.model_dump(exclude={'password'}))
 
 
-@router.get("/me", response_model=User)
+@router.get("/users/me", response_model=User)
 def read_users_me(current_user: Annotated[User, Depends(get_current_user)]):
     """
-    UI-07-02: Get the profile of the current authenticated user.
+    Get the profile of the current authenticated user.
     """
     return current_user
+
+
+@router.patch("/users/me", response_model=User)
+def update_user_me(
+    updates: dict = Body(...),
+    current_user: Annotated[User, Depends(get_current_user)] = None
+):
+    """
+    Update the current user's profile (name, phone, organization).
+    """
+    user_in_db = next((u for u in users_db if u.id == current_user.id), None)
+    if not user_in_db:
+        # This case should ideally not be reached if get_current_user works correctly
+        raise HTTPException(status_code=404, detail="User not found in DB")
+
+    # Update only the allowed fields
+    allowed_fields = ["name", "phone", "organization"]
+    for field, value in updates.items():
+        if field in allowed_fields:
+            setattr(user_in_db, field, value)
+
+    return User(**user_in_db.model_dump(exclude={'password'}))
+
+
+@router.patch("/users/me/password")
+def update_user_password(
+    passwords: dict = Body(...),
+    current_user: Annotated[User, Depends(get_current_user)] = None
+):
+    """
+    Update the current user's password.
+    """
+    user_in_db = next((u for u in users_db if u.id == current_user.id), None)
+    if not user_in_db:
+        raise HTTPException(status_code=404, detail="User not found in DB")
+
+    current_password = passwords.get("currentPassword")
+    new_password = passwords.get("newPassword")
+
+    if not current_password or not new_password:
+        raise HTTPException(status_code=400, detail="Both current and new passwords are required")
+
+    if user_in_db.password != current_password:
+        raise HTTPException(status_code=400, detail="Incorrect current password")
+
+    user_in_db.password = new_password
+    return {"message": "Password updated successfully"}
+
+
+@router.get("/users/me/applications", response_model=List[Application])
+def get_my_applications(current_user: Annotated[User, Depends(get_current_user)]):
+    """
+    Get the current user's application history.
+    This is a mock implementation. In a real app, you would query based on user_id.
+    """
+    # Mock logic: associate users to applications.
+    # In a real system, the application would have a user_id.
+    # For now, let's assume user 1 applied to app 1, user 2 to app 2.
+    if current_user.id == 1:
+        return [app for app in applications_db if app.id == "app_001"]
+    elif current_user.id == 2:
+        return [app for app in applications_db if app.id == "app_002"]
+
+    return []


### PR DESCRIPTION
This commit introduces two major features: a Redoc-based API documentation viewer and a complete mock backend implementation based on the provided OpenAPI specification.

Key changes:

1.  **Redoc API Documentation:**
    - Adds `public/openapi.yml` with the API specification.
    - Adds `public/redoc.html` to render the documentation, available at the `/redoc.html` path to avoid conflicts.

2.  **Backend API Implementation:**
    - Implements a full mock backend using FastAPI.
    - Adds new routers, Pydantic models, and mock data for:
        - Support Programs
        - Incubation Centers - Tech Summaries - Education - Mentors - Search
    - Refactors the `users` router and creates a new `auth` router to align with the specification.
    - Expands the `admin` router to include user and registration management.
    - Adds sample SQL schemas and mock data for all new models.