### PR TITLE
fix(footer): correct version import from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jbio-hub-monorepo",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jbio-hub-monorepo",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "services/*",

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import Icon from '../../atoms/Icon';
-import { version } from '../../../../package.json'; // Import version
+import packageJson from '../../../../package.json'; // Import version
 
 // --- STYLED COMPONENTS ---
 
@@ -152,7 +152,7 @@ const Footer = () => {
         <BottomBar>
           <Copyright>
             <span>© 2024 JBTP. All rights reserved.</span>
-            <Version>v{version}</Version>
+            <Version>v{packageJson.version}</Version>
           </Copyright>
           <div style={{ display: 'flex', gap: DESIGN_SYSTEM.spacing.lg }}>
             {['Privacy Policy', 'Terms of Service', 'Contact'].map((item) => (


### PR DESCRIPTION
Fixes an error where the version was imported as a named export from package.json, which is not supported. The import has been changed to a default import to correctly read the version.