### PR TITLE
feat(announcements): redesign announcements page

### DIFF
--- a/src/components/organisms/AnnouncementsHero/index.tsx
+++ b/src/components/organisms/AnnouncementsHero/index.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+
+// --- STYLED COMPONENTS (Adapted from IncubationHero) ---
+
+const float = keyframes`
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-20px); }
+`;
+
+const HeroWrapper = styled.section`
+  position: relative;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: background 0.8s ease;
+  background: ${DESIGN_SYSTEM.gradients.hero2};
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    min-height: 400px;
+  }
+  @media (min-width: 769px) {
+    min-height: 380px;
+  }
+
+  margin-bottom: ${DESIGN_SYSTEM.spacing['3xl']};
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    margin-bottom: ${DESIGN_SYSTEM.spacing.xl};
+  }
+`;
+
+const BackgroundPattern = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Ccircle cx='30' cy='30' r='10'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  opacity: 0.5;
+`;
+
+const FloatingElement = styled.div`
+  position: absolute;
+  top: 15%;
+  left: 10%;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  animation: ${float} 6s ease-in-out infinite;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    width: 60px;
+    height: 60px;
+  }
+  @media (min-width: 769px) {
+    width: 100px;
+    height: 100px;
+  }
+`;
+
+const ContentWrapper = styled.div`
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 0 ${DESIGN_SYSTEM.spacing.lg} ${DESIGN_SYSTEM.spacing.xl};
+  max-width: 1200px;
+  width: 100%;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding-bottom: ${DESIGN_SYSTEM.spacing.lg};
+  }
+`;
+
+const Title = styled.h1`
+  font-weight: 900;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.md} 0;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 32px;
+  }
+  @media (min-width: 769px) {
+    font-size: 48px;
+  }
+`;
+
+const Subtitle = styled.p`
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.6;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 16px;
+  }
+  @media (min-width: 769px) {
+    font-size: 18px;
+  }
+`;
+
+// --- COMPONENT ---
+
+const AnnouncementsHero = () => {
+  return (
+    <HeroWrapper>
+      <BackgroundPattern />
+      <FloatingElement />
+      <ContentWrapper>
+        <Title>
+          JB 지원사업공고
+        </Title>
+        <Subtitle>
+          전북 바이오산업의 성장을 위한 다양한 지원사업을 확인하세요.
+        </Subtitle>
+      </ContentWrapper>
+    </HeroWrapper>
+  );
+};
+
+export default AnnouncementsHero;

--- a/src/components/pages/AnnouncementsPage/index.tsx
+++ b/src/components/pages/AnnouncementsPage/index.tsx
@@ -1,16 +1,13 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { DESIGN_SYSTEM } from '../../../styles/tokens';
 import MainLayout from '../../templates/MainLayout';
 import AnnouncementList from '../../organisms/AnnouncementList';
 import AnnouncementsDashboard from '../../organisms/AnnouncementsDashboard';
 import Tabs from '../../molecules/Tabs';
-import useSupportPrograms from '../../../hooks/useSupportPrograms'; // Import the CORRECT hook
+import useSupportPrograms from '../../../hooks/useSupportPrograms';
+import AnnouncementsHero from '../../organisms/AnnouncementsHero';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
 
-// --- DATA MODELS ---
-// Mock data and old interfaces are removed.
-
-// Note: These categories should align with backend mock data for filtering to work.
 const TABS = [
   { id: 'all', label: '전체' },
   { id: 'R&D', label: 'R&D' },
@@ -19,38 +16,14 @@ const TABS = [
   { id: '제조혁신', label: '제조혁신' },
 ];
 
-
-// --- STYLED COMPONENTS ---
-
-const PageWrapper = styled.div`
+const ContentWrapper = styled.div`
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0 2rem 2rem;
 
   @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    padding: 1.5rem 1rem;
+    padding: 0 1rem 1.5rem;
   }
-`;
-
-const PageHeader = styled.header`
-  margin-bottom: 2.5rem;
-  text-align: center;
-`;
-
-const PageTitle = styled.h1`
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: #111827;
-  margin-bottom: 0.5rem;
-
-  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    font-size: 2rem;
-  }
-`;
-
-const PageSubtitle = styled.p`
-  font-size: 1.125rem;
-  color: #4b5563;
 `;
 
 const LoadingMessage = styled.p`
@@ -64,37 +37,26 @@ const ErrorMessage = styled(LoadingMessage)`
   color: #ef4444;
 `;
 
-// --- COMPONENT ---
-
 const AnnouncementsPage = () => {
   const [activeTab, setActiveTab] = useState('all');
 
-  // Use the correct hook to fetch data based on the active tab
   const { data, loading, error } = useSupportPrograms({
     category: activeTab === 'all' ? undefined : activeTab,
-    limit: 100, // Fetch a large number for now
+    limit: 100,
   });
 
   const programs = data ? data.data : [];
 
   return (
     <MainLayout>
-      <PageWrapper>
-        <PageHeader>
-          <PageTitle>JB 지원사업공고</PageTitle>
-          <PageSubtitle>전북 바이오산업의 성장을 위한 다양한 지원사업을 확인하세요.</PageSubtitle>
-        </PageHeader>
-
-        {/* This component might need its own data hook later */}
+      <AnnouncementsHero />
+      <ContentWrapper>
         <AnnouncementsDashboard />
-
         <Tabs tabs={TABS} activeTab={activeTab} onTabClick={setActiveTab} />
-
         {loading && <LoadingMessage>지원사업 공고를 불러오는 중입니다...</LoadingMessage>}
         {error && <ErrorMessage>오류가 발생했습니다: {error.message}</ErrorMessage>}
         {!loading && !error && <AnnouncementList programs={programs} />}
-
-      </PageWrapper>
+      </ContentWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
Redesigns the announcements page to have a more modern, landing-page-like feel, similar to the home page.

- Creates a new `AnnouncementsHero` component with a static hero section for the announcements page.
- Replaces the old text header on the announcements page with the new hero component.
- Adjusts the layout to accommodate the new hero section while retaining the existing content.