### PR TITLE
feat(news): redesign news page

### DIFF
--- a/src/components/organisms/NewsHero/index.tsx
+++ b/src/components/organisms/NewsHero/index.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+import { DESIGN_SYSTEM } from '../../../styles/tokens';
+
+// --- STYLED COMPONENTS (Adapted from AnnouncementsHero) ---
+
+const float = keyframes`
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-20px); }
+`;
+
+const HeroWrapper = styled.section`
+  position: relative;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: background 0.8s ease;
+  background: ${DESIGN_SYSTEM.gradients.hero3};
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    min-height: 400px;
+  }
+  @media (min-width: 769px) {
+    min-height: 380px;
+  }
+
+  margin-bottom: ${DESIGN_SYSTEM.spacing['3xl']};
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    margin-bottom: ${DESIGN_SYSTEM.spacing.xl};
+  }
+`;
+
+const BackgroundPattern = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Ccircle cx='30' cy='30' r='10'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  opacity: 0.5;
+`;
+
+const FloatingElement = styled.div`
+  position: absolute;
+  top: 15%;
+  left: 10%;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  animation: ${float} 6s ease-in-out infinite;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    width: 60px;
+    height: 60px;
+  }
+  @media (min-width: 769px) {
+    width: 100px;
+    height: 100px;
+  }
+`;
+
+const ContentWrapper = styled.div`
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 0 ${DESIGN_SYSTEM.spacing.lg} ${DESIGN_SYSTEM.spacing.xl};
+  max-width: 1200px;
+  width: 100%;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    padding-bottom: ${DESIGN_SYSTEM.spacing.lg};
+  }
+`;
+
+const Title = styled.h1`
+  font-weight: 900;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 ${DESIGN_SYSTEM.spacing.md} 0;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 32px;
+  }
+  @media (min-width: 769px) {
+    font-size: 48px;
+  }
+`;
+
+const Subtitle = styled.p`
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.6;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
+    font-size: 16px;
+  }
+  @media (min-width: 769px) {
+    font-size: 18px;
+  }
+`;
+
+// --- COMPONENT ---
+
+const NewsHero = () => {
+  return (
+    <HeroWrapper>
+      <BackgroundPattern />
+      <FloatingElement />
+      <ContentWrapper>
+        <Title>
+          산업·기술 뉴스
+        </Title>
+        <Subtitle>
+          국내외 바이오 산업 및 기술의 최신 동향과 정보를 확인하세요.
+        </Subtitle>
+      </ContentWrapper>
+    </HeroWrapper>
+  );
+};
+
+export default NewsHero;

--- a/src/components/pages/NewsListPage/index.tsx
+++ b/src/components/pages/NewsListPage/index.tsx
@@ -7,9 +7,11 @@ import Pagination from '../../molecules/Pagination';
 import Grid from '../../atoms/Grid';
 import NewsCard from '../../molecules/NewsCard';
 import { News } from '../../../types/api';
+import NewsHero from '../../organisms/NewsHero';
 
 // --- MOCK DATA ---
 const mockNewsList: News[] = [
+  // (mock data is the same as before)
   {
     id: 1,
     title: '혁신적인 암 치료법, CAR-T 세포 치료의 최신 동향',
@@ -45,40 +47,20 @@ const mockNewsList: News[] = [
   { id: 6, title: '뇌-컴퓨터 인터페이스(BCI), 상용화 어디까지 왔나', summary: '일론 머스크의 뉴럴링크를 비롯한 BCI 기술의 발전 현황과 윤리적 과제를 짚어본다.', content: '상세 내용...', thumbnailUrl: 'https://picsum.photos/seed/news6/400/225', sourceName: '테크월드', created_at: '2024-08-09', category: 'news' },
 ];
 
-
 // --- STYLED COMPONENTS ---
 
-const PageWrapper = styled.div`
+const ContentWrapper = styled.div`
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0 2rem 2rem;
 
   @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    padding: 1.5rem 1rem;
+    padding: 0 1rem 1.5rem;
   }
 `;
 
-const PageHeader = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+const SearchBarContainer = styled.div`
   margin-bottom: 2.5rem;
-  flex-wrap: wrap;
-  gap: 1rem;
-
-  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
-const PageTitle = styled.h1`
-  font-size: 2rem;
-  font-weight: 700;
-
-  @media ${DESIGN_SYSTEM.mediaQueries.mobile} {
-    font-size: 1.75rem;
-  }
 `;
 
 // --- COMPONENT ---
@@ -86,11 +68,11 @@ const PageTitle = styled.h1`
 const NewsListPage = () => {
   return (
     <MainLayout>
-      <PageWrapper>
-        <PageHeader>
-          <PageTitle>최신 뉴스</PageTitle>
+      <NewsHero />
+      <ContentWrapper>
+        <SearchBarContainer>
           <SearchBar />
-        </PageHeader>
+        </SearchBarContainer>
 
         <Grid $cols={3} $tabletCols={2} $mobileCols={1} $gap="1.5rem">
           {mockNewsList.map((news) => (
@@ -99,7 +81,7 @@ const NewsListPage = () => {
         </Grid>
 
         <Pagination currentPage={1} totalPages={10} />
-      </PageWrapper>
+      </ContentWrapper>
     </MainLayout>
   );
 };


### PR DESCRIPTION
Redesigns the news page to have a more modern, landing-page-like feel, similar to the home page.

- Creates a new `NewsHero` component with a static hero section for the news page.
- Replaces the old text header on the news page with the new hero component.
- Moves the `SearchBar` to the main content area below the hero.
- Adjusts the layout to accommodate the new hero section and search bar.