### PR TITLE
feat: Implement company information and article pages

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date
 from ..models.announcement import Announcement, FileLink, RelatedLink
-from ..models.company import Company
+from ..models.company import Company, CompanyContact, SizeCategory
+from ..models.article import Article
 from ..models.infra import Infra
 from ..models.content import News, Event, Tech
 from ..models.consultation import Consultation
@@ -121,38 +122,59 @@ CREATE TABLE companies (
 );
 """
 
-companies_db: list[Company] = [
-    Company(
-        id=1,
-        name='(주)바이오노트',
-        type='기업',
-        description='동물용 진단제품 개발 및 제조를 선도하는 기업입니다.',
-        address='전라북도 익산시 왕궁면 국가식품로 100',
-        contact_person='김담당',
-        contact_email='contact@bionote.co.kr',
-        contact_phone='063-123-4567'
+companies_db: dict[str, Company] = {
+    "comp-001": Company(
+        id="comp-001",
+        name="전북 바이오텍",
+        logoUrl="https://picsum.photos/seed/comp1/200/200",
+        industry="레드 바이오",
+        region="전주시",
+        foundedYear=2020,
+        sizeCategory=SizeCategory.STARTUP,
+        employees=15,
+        description="AI 기반 신약 개발 스타트업입니다. 혁신적인 기술로 난치병 치료에 도전합니다.",
+        products=["JB-Drug-01", "JB-Drug-02"],
+        achievements=["2023년 기술혁신상 수상", "시리즈 A 투자 유치 (100억)"],
+        patents=["KR-10-2023-0012345", "US-11-2024-0054321"],
+        contact=CompanyContact(name="김담당", email="contact@jb-biotech.com", phone="063-111-2222"),
+        websiteUrl="https://jb-biotech.com",
+        relatedArticles=["article-001"]
     ),
-    Company(
-        id=2,
-        name='한국생명공학연구원 전북분원',
-        type='기관',
-        description='생명공학 분야의 국가 거점 연구기관입니다.',
-        address='전라북도 정읍시 입암면 첨단과기로 241',
-        contact_person='이연구원',
-        contact_email='info@kribb.re.kr',
-        contact_phone='063-570-5600'
+    "comp-002": Company(
+        id="comp-002",
+        name="그린 애그리",
+        logoUrl="https://picsum.photos/seed/comp2/200/200",
+        industry="그린 바이오",
+        region="김제시",
+        foundedYear=2015,
+        sizeCategory=SizeCategory.SME,
+        employees=55,
+        description="친환경 농업 솔루션을 제공하는 중견기업입니다. 스마트팜과 미생물 비료가 주력입니다.",
+        products=["스마트팜 제어 시스템 v2", "유기농 미생물 비료"],
+        achievements=["2022년 농림축산식품부 장관상 수상"],
+        patents=["KR-10-2021-0098765"],
+        contact=CompanyContact(name="박팀장", email="sales@greenagri.co.kr", phone="063-333-4444"),
+        websiteUrl="https://greenagri.co.kr",
+        relatedArticles=["article-002"]
     ),
-    Company(
-        id=3,
-        name='전북대학교 병원',
-        type='기관',
-        description='지역 거점 국립대학교 병원. 임상 연구 및 시험 진행.',
-        address='전라북도 전주시 덕진구 건지로 20',
-        contact_person='최교수',
-        contact_email='med@jbnu.ac.kr',
-        contact_phone='063-250-1114'
+    "comp-003": Company(
+        id="comp-003",
+        name="화이트 산업",
+        logoUrl="https://picsum.photos/seed/comp3/200/200",
+        industry="화이트 바이오",
+        region="군산시",
+        foundedYear=2008,
+        sizeCategory=SizeCategory.LARGE,
+        employees=320,
+        description="바이오 플라스틱 및 친환경 소재를 개발, 생산하는 대기업입니다.",
+        products=["생분해성 플라스틱 (PLA)", "바이오에탄올"],
+        achievements=[],
+        patents=["KR-10-2018-0055555", "KR-10-2020-0077777"],
+        contact=CompanyContact(name="이부장", email="info@white-industry.com", phone="063-555-6666"),
+        websiteUrl="https://white-industry.com",
+        relatedArticles=[]
     )
-]
+}
 
 # SQL Schema for Infrastructure
 """
@@ -799,3 +821,34 @@ registration_requests_db: list[RegistrationRequest] = [
         status="pending"
     )
 ]
+
+# ===== New Mock Data for Company/Article Features =====
+
+articles_db: dict[str, Article] = {
+    "article-001": Article(
+        id="article-001",
+        title="전북 바이오텍, AI로 신약 개발 기간 2년 단축",
+        author="이코노미 저널",
+        publishDate=date(2024, 7, 22),
+        tags=["AI", "신약개발", "스타트업"],
+        contentHTML="<h1>AI, 신약 개발의 새로운 희망</h1><p>전북 바이오텍이 자체 개발한 AI 플랫폼 'JB-Discovery'를 통해 신약 후보물질 발굴 기간을 평균 4년에서 2년으로 단축하는 데 성공했다고 밝혔다...</p>",
+        images=["https://picsum.photos/seed/article1/800/400"],
+        relatedCompanies=["comp-001"]
+    ),
+    "article-002": Article(
+        id="article-002",
+        title="[인터뷰] 그린 애그리의 박팀장, '지속가능한 농업이 미래입니다'",
+        author="농업과 미래",
+        publishDate=date(2024, 6, 15),
+        tags=["그린바이오", "스마트팜", "친환경"],
+        contentHTML="<h1>지속가능한 농업을 향한 열정</h1><p>김제시에 위치한 그린 애그리는 최근 유기농 미생물 비료로 업계의 주목을 받고 있다. 그린 애그리의 박팀장을 만나 이야기를 들어보았다...</p>",
+        images=["https://picsum.photos/seed/article2/800/400"],
+        relatedCompanies=["comp-002"]
+    ),
+}
+
+bookmarks_db = {
+    # user_id: { "companies": set(), "articles": set() }
+    1: {"companies": {"comp-001", "comp-003"}, "articles": {"article-002"}},
+    2: {"companies": set(), "articles": {"article-001"}},
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
 
 # --- API Routers ---
 # Routers for each domain will be included here to modularize the application.
-from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster, support_program, incubation_center, technology, education, mentor, search, auth
+from .routers import announcement, company, infra, content, consultation, user, admin, service, stat, cluster, support_program, incubation_center, technology, education, mentor, search, auth, article
 
 app.include_router(announcement.router, prefix="/api")
 app.include_router(company.router, prefix="/api")
@@ -37,6 +37,7 @@ app.include_router(education.router, prefix="/api")
 app.include_router(mentor.router, prefix="/api")
 app.include_router(search.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
+app.include_router(article.router, prefix="/api")
 # ...
 
 

--- a/backend/models/article.py
+++ b/backend/models/article.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, HttpUrl
+from typing import List, Optional
+import datetime
+
+
+class Article(BaseModel):
+    id: str
+    title: str
+    author: str
+    publishDate: datetime.date
+    tags: List[str] = []
+    contentHTML: str
+    images: List[HttpUrl] = []
+    relatedCompanies: List[str] = []

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import List, TypeVar, Generic
+
+
+T = TypeVar('T')
+
+
+class Pagination(BaseModel):
+    page: int
+    limit: int
+    total: int
+    totalPages: int
+    hasNext: bool
+    hasPrev: bool
+
+
+class PaginatedResponse(Generic[T], BaseModel):
+    data: List[T]
+    pagination: Pagination

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -1,12 +1,39 @@
-from pydantic import BaseModel, EmailStr
-from typing import Optional
+from pydantic import BaseModel, EmailStr, HttpUrl
+from typing import List, Optional, Dict
+from enum import Enum
+
+
+class CompanyContact(BaseModel):
+    name: str
+    email: EmailStr
+    phone: str
+
+
+class SizeCategory(str, Enum):
+    STARTUP = "Startup"
+    SME = "SME"
+    LARGE = "Large"
+
 
 class Company(BaseModel):
-    id: int
+    id: str
     name: str
-    type: str  # '기업' or '기관'
-    description: Optional[str] = None
-    address: Optional[str] = None
-    contact_person: Optional[str] = None
-    contact_email: Optional[EmailStr] = None
-    contact_phone: Optional[str] = None
+    logoUrl: Optional[str] = None # Using str for now, as HttpUrl can be strict
+    industry: str
+    region: str
+    foundedYear: int
+    sizeCategory: SizeCategory
+    employees: int
+    description: str
+    products: List[str] = []
+    achievements: List[str] = []
+    patents: List[str] = []
+    contact: CompanyContact
+    websiteUrl: Optional[str] = None # Using str for now
+    relatedArticles: List[str] = []
+
+
+class CompanyStats(BaseModel):
+    totalCount: int
+    regionDistribution: Dict[str, int]
+    sizeDistribution: Dict[str, int]

--- a/backend/routers/article.py
+++ b/backend/routers/article.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, HTTPException, status, Query
+from typing import List, Optional
+import datetime
+
+from ..models.article import Article
+from ..models.common import PaginatedResponse
+from ..db.mock_data import articles_db
+
+# TODO: This helper should be moved to a common util file to avoid duplication.
+def paginate(items: List, page: int, limit: int) -> dict:
+    total_items = len(items)
+    if limit == 0:
+        total_pages = 1 if total_items > 0 else 0
+    else:
+        total_pages = (total_items + limit - 1) // limit
+
+    start = (page - 1) * limit
+    end = start + limit
+    paginated_items = items[start:end]
+
+    return {
+        "data": paginated_items,
+        "pagination": {
+            "page": page,
+            "limit": limit,
+            "total": total_items,
+            "totalPages": total_pages,
+            "hasNext": page < total_pages,
+            "hasPrev": page > 1,
+        }
+    }
+
+
+router = APIRouter(
+    prefix="/articles",
+    tags=["articles"],
+)
+
+@router.get("", response_model=PaginatedResponse[Article])
+def get_articles(
+    page: int = 1,
+    limit: int = 10,
+    tag: Optional[str] = None,
+    publishDate: Optional[str] = Query(None, description="Filter by publication month in YYYY-MM format"),
+    sort: Optional[str] = Query("latest", enum=["latest", "popularity"]),
+):
+    """
+    Get a list of articles with filtering, sorting, and pagination.
+    """
+    results = list(articles_db.values())
+
+    if tag:
+        results = [a for a in results if tag in a.tags]
+    if publishDate:
+        try:
+            year, month = map(int, publishDate.split('-'))
+            results = [a for a in results if a.publishDate.year == year and a.publishDate.month == month]
+        except (ValueError, AttributeError):
+            raise HTTPException(status_code=400, detail="Invalid publishDate format. Use YYYY-MM.")
+
+    if sort == "latest":
+        results.sort(key=lambda a: a.publishDate, reverse=True)
+    elif sort == "popularity":
+        # Popularity is not a real field in the mock data, so we can't sort by it.
+        # In a real application, this would be based on view counts or similar metrics.
+        pass
+
+    return paginate(results, page, limit)
+
+
+@router.get("/{id}", response_model=Article)
+def get_article(id: str):
+    """
+    Get details of a single article by its ID.
+    """
+    article = articles_db.get(id)
+    if article is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article with ID {id} not found",
+        )
+    return article

--- a/backend/routers/company.py
+++ b/backend/routers/company.py
@@ -1,33 +1,126 @@
 from fastapi import APIRouter, HTTPException, status, Query
 from typing import List, Optional
 
-from ..models.company import Company
+from ..models.company import Company, SizeCategory, CompanyStats
+from ..models.common import PaginatedResponse
 from ..db.mock_data import companies_db
 
 router = APIRouter(
     prefix="/companies",
-    tags=["Companies & Institutions"],
+    tags=["companies"],
 )
 
-@router.get("", response_model=List[Company])
-def get_companies(type: Optional[str] = Query(None, description="Filter by type: '기업' or '기관'")):
-    """
-    UI-02-01: Get a list of all companies and institutions.
-    Can be filtered by type.
-    """
-    if type:
-        return [company for company in companies_db if company.type == type]
-    return companies_db
+def paginate(items: List, page: int, limit: int) -> dict:
+    total_items = len(items)
+    if limit == 0:
+        total_pages = 1 if total_items > 0 else 0
+    else:
+        total_pages = (total_items + limit - 1) // limit
 
-@router.get("/{company_id}", response_model=Company)
-def get_company(company_id: int):
+    start = (page - 1) * limit
+    end = start + limit
+    paginated_items = items[start:end]
+
+    return {
+        "data": paginated_items,
+        "pagination": {
+            "page": page,
+            "limit": limit,
+            "total": total_items,
+            "totalPages": total_pages,
+            "hasNext": page < total_pages,
+            "hasPrev": page > 1,
+        }
+    }
+
+@router.get("", response_model=PaginatedResponse[Company])
+def get_companies(
+    page: int = 1,
+    limit: int = 20,
+    region: Optional[str] = None,
+    industry: Optional[str] = None,
+    sizeCategory: Optional[SizeCategory] = None,
+    hasInvestment: Optional[bool] = None,
+    sort: Optional[str] = Query(None, description="Sort order", enum=["latest", "name", "investmentSize"]),
+    keyword: Optional[str] = None,
+):
     """
-    UI-02-02: Get details of a single company or institution by its ID.
+    Get a list of companies with filtering, sorting, and pagination.
     """
-    company = next((comp for comp in companies_db if comp.id == company_id), None)
+    results = list(companies_db.values())
+
+    if region:
+        results = [c for c in results if c.region == region]
+    if industry:
+        results = [c for c in results if c.industry == industry]
+    if sizeCategory:
+        results = [c for c in results if c.sizeCategory == sizeCategory]
+    if hasInvestment is not None:
+        results = [c for c in results if ("investment" in "".join(c.achievements).lower()) == hasInvestment]
+    if keyword:
+        keyword = keyword.lower()
+        results = [c for c in results if keyword in c.name.lower() or keyword in c.description.lower()]
+
+    if sort:
+        if sort == "name":
+            results.sort(key=lambda c: c.name)
+        elif sort == "latest":
+            results.sort(key=lambda c: c.foundedYear, reverse=True)
+        # Note: investmentSize sorting is not implemented as mock data lacks this field.
+
+    return paginate(results, page, limit)
+
+@router.get("/stats", response_model=CompanyStats)
+def get_company_stats():
+    """
+    Get statistics for the company dashboard.
+    """
+    results = list(companies_db.values())
+    total_count = len(results)
+
+    region_dist = {}
+    for company in results:
+        region_dist[company.region] = region_dist.get(company.region, 0) + 1
+
+    size_dist = {
+        "startup": len([c for c in results if c.sizeCategory == SizeCategory.STARTUP]),
+        "sme": len([c for c in results if c.sizeCategory == SizeCategory.SME]),
+        "large": len([c for c in results if c.sizeCategory == SizeCategory.LARGE]),
+    }
+
+    return {
+        "totalCount": total_count,
+        "regionDistribution": region_dist,
+        "sizeDistribution": size_dist,
+    }
+
+@router.get("/compare", response_model=List[Company])
+def compare_companies(ids: str = Query(..., description="Comma-separated list of company IDs to compare")):
+    """
+    Compare up to 3 companies by their IDs.
+    """
+    id_list = [i.strip() for i in ids.split(',')]
+    if len(id_list) > 3:
+        raise HTTPException(status_code=400, detail="Cannot compare more than 3 companies.")
+
+    results = [companies_db.get(id) for id in id_list if companies_db.get(id)]
+
+    if len(results) != len(id_list):
+        found_ids = {c.id for c in results}
+        missing_ids = [id for id in id_list if id not in found_ids]
+        raise HTTPException(status_code=404, detail=f"Company IDs not found: {', '.join(missing_ids)}")
+
+    return results
+
+@router.get("/{id}", response_model=Company)
+def get_company(id: str):
+    """
+    Get details of a single company by its ID.
+    """
+    company = companies_db.get(id)
     if company is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Company or institution with ID {company_id} not found",
+            detail=f"Company with ID {id} not found",
         )
     return company

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -37,6 +37,8 @@ tags:
     description: 전문가 멘토링 API
   - name: companies
     description: 바이오 기업 DB API
+  - name: articles
+    description: 인터뷰 및 기획기사 API
   - name: statistics
     description: 성과관리 통계 API
   - name: notices
@@ -254,6 +256,206 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Application'
+
+  /users/me/bookmarks/companies:
+    get:
+      tags: [users]
+      summary: 내 기업 북마크 목록 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 북마크한 기업 목록
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Company'
+    post:
+      tags: [users]
+      summary: 기업 북마크 추가
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [companyId]
+              properties:
+                companyId:
+                  type: string
+      responses:
+        '201':
+          description: 북마크 추가 성공
+
+  /users/me/bookmarks/companies/{companyId}:
+    delete:
+      tags: [users]
+      summary: 기업 북마크 삭제
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 북마크 삭제 성공
+
+  /users/me/bookmarks/articles:
+    get:
+      tags: [users]
+      summary: 내 기사 북마크 목록 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 북마크한 기사 목록
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Article'
+    post:
+      tags: [users]
+      summary: 기사 북마크 추가
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [articleId]
+              properties:
+                articleId:
+                  type: string
+      responses:
+        '201':
+          description: 북마크 추가 성공
+
+  /users/me/bookmarks/articles/{articleId}:
+    delete:
+      tags: [users]
+      summary: 기사 북마크 삭제
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: articleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 북마크 삭제 성공
+
+  /users/me/bookmarks/companies:
+    get:
+      tags: [users]
+      summary: 내 기업 북마크 목록 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 북마크한 기업 목록
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Company'
+    post:
+      tags: [users]
+      summary: 기업 북마크 추가
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [companyId]
+              properties:
+                companyId:
+                  type: string
+      responses:
+        '201':
+          description: 북마크 추가 성공
+
+  /users/me/bookmarks/companies/{companyId}:
+    delete:
+      tags: [users]
+      summary: 기업 북마크 삭제
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 북마크 삭제 성공
+
+  /users/me/bookmarks/articles:
+    get:
+      tags: [users]
+      summary: 내 기사 북마크 목록 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 북마크한 기사 목록
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Article'
+    post:
+      tags: [users]
+      summary: 기사 북마크 추가
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [articleId]
+              properties:
+                articleId:
+                  type: string
+      responses:
+        '201':
+          description: 북마크 추가 성공
+
+  /users/me/bookmarks/articles/{articleId}:
+    delete:
+      tags: [users]
+      summary: 기사 북마크 삭제
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: articleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 북마크 삭제 성공
 
   # ===== 기업지원사업 API =====
   /support-programs:
@@ -591,14 +793,33 @@ paths:
           schema:
             type: integer
             default: 20
+        - name: region
+          in: query
+          description: 지역 필터
+          schema:
+            type: string
         - name: industry
           in: query
+          description: 산업분야 필터
           schema:
             type: string
-        - name: location
+        - name: sizeCategory
           in: query
+          description: 기업규모 필터
           schema:
             type: string
+            enum: [Startup, SME, Large]
+        - name: hasInvestment
+          in: query
+          description: 투자유치 여부 필터
+          schema:
+            type: boolean
+        - name: sort
+          in: query
+          description: 정렬 기준
+          schema:
+            type: string
+            enum: [latest, name, investmentSize]
         - name: keyword
           in: query
           schema:
@@ -635,6 +856,128 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Company'
+
+  /companies/stats:
+    get:
+      tags: [companies]
+      summary: 기업 대시보드 통계 조회
+      responses:
+        '200':
+          description: 기업 관련 주요 통계
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totalCount:
+                    type: integer
+                    description: 총 등록 기업 수
+                  regionDistribution:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                    description: 지역별 기업 분포
+                  sizeDistribution:
+                    type: object
+                    properties:
+                      startup:
+                        type: integer
+                      sme:
+                        type: integer
+                      large:
+                        type: integer
+                    description: 업력별 기업 분포 (스타트업/중견/대기업)
+
+  /companies/compare:
+    get:
+      tags: [companies]
+      summary: 기업 비교
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          description: 비교할 기업 ID 목록 (쉼표로 구분, 최대 3개)
+          schema:
+            type: string
+            example: "comp-1,comp-2,comp-3"
+      responses:
+        '200':
+          description: 비교할 기업들의 상세 정보 목록
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Company'
+        '400':
+          description: 잘못된 요청 (e.g., ID 개수 초과)
+
+  # ===== 인터뷰 및 기획기사 API =====
+  /articles:
+    get:
+      tags: [articles]
+      summary: 기사 목록 조회
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: tag
+          in: query
+          description: 분야/테마 태그 필터
+          schema:
+            type: string
+        - name: publishDate
+          in: query
+          description: 발행일 필터 (YYYY-MM)
+          schema:
+            type: string
+            format: date
+        - name: sort
+          in: query
+          description: 정렬 기준
+          schema:
+            type: string
+            enum: [latest, popularity]
+            default: latest
+      responses:
+        '200':
+          description: 기사 목록
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Article'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+
+  /articles/{id}:
+    get:
+      tags: [articles]
+      summary: 기사 상세 조회
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 기사 상세 정보
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Article'
 
   # ===== 성과관리 통계 API =====
   /statistics/kpis:
@@ -1264,30 +1607,111 @@ components:
       properties:
         id:
           type: string
+          example: "comp-001"
         name:
           type: string
+          example: "전북 바이오텍"
+        logoUrl:
+          type: string
+          format: url
+          example: "https://example.com/logo.png"
         industry:
           type: string
-        establishedYear:
+          example: "레드 바이오"
+        region:
+          type: string
+          example: "전주시"
+        foundedYear:
           type: integer
-        ceo:
+          example: 2020
+        sizeCategory:
           type: string
-        products:
-          type: string
-        location:
-          type: string
-        contact:
-          type: string
-        revenue:
-          type: number
+          enum: [Startup, SME, Large]
+          example: "Startup"
         employees:
           type: integer
-        certification:
+          example: 15
+        description:
+          type: string
+          example: "AI 기반 신약 개발 스타트업입니다."
+        products:
           type: array
           items:
             type: string
-        exportStatus:
-          type: boolean
+          example: ["JB-Drug-01", "JB-Drug-02"]
+        achievements:
+          type: array
+          items:
+            type: string
+          example: ["2023년 기술혁신상 수상"]
+        patents:
+          type: array
+          items:
+            type: string
+          example: ["KR-10-2023-0012345"]
+        contact:
+          $ref: '#/components/schemas/CompanyContact'
+        websiteUrl:
+          type: string
+          format: url
+          example: "https://jeonbuk-bio.kr"
+        relatedArticles:
+          type: array
+          items:
+            type: string # Article ID
+          example: ["article-001", "article-002"]
+
+    CompanyContact:
+      type: object
+      description: 기업 담당자 정보
+      properties:
+        name:
+          type: string
+          example: "김담당"
+        email:
+          type: string
+          format: email
+          example: "contact@company.com"
+        phone:
+          type: string
+          example: "063-123-4567"
+
+    Article:
+      type: object
+      description: 인터뷰 및 기획기사
+      properties:
+        id:
+          type: string
+          example: "article-001"
+        title:
+          type: string
+          example: "전북 바이오텍, AI로 신약 개발 기간 단축"
+        author:
+          type: string
+          example: "이 기자"
+        publishDate:
+          type: string
+          format: date
+          example: "2024-08-19"
+        tags:
+          type: array
+          items:
+            type: string
+          example: ["AI", "신약개발", "스타트업"]
+        contentHTML:
+          type: string
+          example: "<h1>기사 본문</h1><p>내용...</p>"
+        images:
+          type: array
+          items:
+            type: string
+            format: url
+          example: ["https://example.com/image1.jpg"]
+        relatedCompanies:
+          type: array
+          items:
+            type: string # Company ID
+          example: ["comp-001"]
 
     KPI:
       type: object

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,10 @@ import TechOutcomesPage from './components/pages/TechOutcomesPage';
 import TechTransferPage from './components/pages/TechTransferPage';
 import TechCollaborationPage from './components/pages/TechCollaborationPage';
 import TechDetailPage from './components/pages/TechDetailPage';
+import CompanyDashboardPage from './components/pages/CompanyDashboardPage';
+import CompanyDetailPage from './components/pages/CompanyDetailPage';
+import ArticleListPage from './components/pages/ArticleListPage';
+import ArticleDetailPage from './components/pages/ArticleDetailPage';
 
 function App() {
   return (
@@ -68,7 +72,12 @@ function App() {
       <Route path="/tech/collaboration" element={<TechCollaborationPage />} />
       <Route path="/tech/:type/:id" element={<TechDetailPage />} />
 
+      {/* Company & Article Routes */}
+      <Route path="/company" element={<CompanyDashboardPage />} />
       <Route path="/companies" element={<CompaniesPage />} />
+      <Route path="/companies/:id" element={<CompanyDetailPage />} />
+      <Route path="/articles" element={<ArticleListPage />} />
+      <Route path="/articles/:id" element={<ArticleDetailPage />} />
     </Routes>
   );
 }

--- a/src/components/molecules/ArticleCard/index.tsx
+++ b/src/components/molecules/ArticleCard/index.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Article } from '../../../types/api';
+import Badge from '../../atoms/Badge';
+
+const CardLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  height: 100%;
+`;
+
+const CardWrapper = styled.div`
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const ThumbnailWrapper = styled.div`
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: #f3f4f6;
+  border-bottom: 1px solid #e5e7eb;
+`;
+
+const Thumbnail = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const ContentWrapper = styled.div`
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+const Title = styled.h3`
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0 0 0.75rem 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  flex-grow: 1;
+`;
+
+const TagList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding-top: 1rem;
+  margin-top: auto;
+  border-top: 1px solid #f3f4f6;
+`;
+
+interface ArticleCardProps {
+  article: Article;
+}
+
+const ArticleCard: React.FC<ArticleCardProps> = ({ article }) => {
+  return (
+    <CardLink to={`/articles/${article.id}`}>
+      <CardWrapper>
+        <ThumbnailWrapper>
+          {article.images && article.images[0] ? (
+            <Thumbnail src={article.images[0]} alt={article.title} loading="lazy" />
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#9ca3af' }}>
+              <span>No Image</span>
+            </div>
+          )}
+        </ThumbnailWrapper>
+        <ContentWrapper>
+          <Title>{article.title}</Title>
+          <TagList>
+            {article.tags.slice(0, 3).map(tag => (
+              <Badge key={tag} variant="secondary">{tag}</Badge>
+            ))}
+          </TagList>
+          <Footer>
+            <span>{article.author}</span>
+            <span>{new Date(article.publishDate).toLocaleDateString()}</span>
+          </Footer>
+        </ContentWrapper>
+      </CardWrapper>
+    </CardLink>
+  );
+};
+
+export default ArticleCard;

--- a/src/components/molecules/CompanyCard/index.tsx
+++ b/src/components/molecules/CompanyCard/index.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Company } from '../../../types/api';
+import Badge from '../../atoms/Badge';
+
+const CardWrapper = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background-color: white;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.2s ease-in-out;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  &:hover {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  }
+`;
+
+const CardHeader = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const Logo = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin-right: 1rem;
+  object-fit: cover;
+  border: 1px solid #f3f4f6;
+`;
+
+const NameAndMeta = styled.div``;
+
+const CompanyName = styled.h3`
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+  color: #111827;
+`;
+
+const CompanyMeta = styled.p`
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0;
+`;
+
+const Description = styled.p`
+  color: #4b5563;
+  font-size: 1rem;
+  flex-grow: 1;
+  margin: 0 0 1.5rem;
+  line-height: 1.5;
+`;
+
+const TagList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+`;
+
+interface CompanyCardProps {
+  company: Company;
+  onClick: () => void;
+}
+
+const CompanyCard: React.FC<CompanyCardProps> = ({ company, onClick }) => {
+  return (
+    <CardWrapper onClick={onClick} style={{ cursor: 'pointer' }}>
+      <CardHeader>
+        <Logo
+          src={company.logoUrl || `https://ui-avatars.com/api/?name=${company.name}&background=random`}
+          alt={`${company.name} logo`}
+        />
+        <NameAndMeta>
+          <CompanyName>{company.name}</CompanyName>
+          <CompanyMeta>{company.industry} &middot; {company.region}</CompanyMeta>
+        </NameAndMeta>
+      </CardHeader>
+      <Description>{company.description}</Description>
+      <TagList>
+        <Badge>{company.sizeCategory}</Badge>
+        {company.products.slice(0, 2).map(product => (
+          <Badge key={product} variant="secondary">{product}</Badge>
+        ))}
+      </TagList>
+    </CardWrapper>
+  );
+};
+
+export default CompanyCard;

--- a/src/components/pages/ArticleDetailPage/index.tsx
+++ b/src/components/pages/ArticleDetailPage/index.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import styled from 'styled-components';
+import useArticle from '../../../hooks/useArticle';
+import MainLayout from '../../templates/MainLayout';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import { ErrorState } from '../../molecules/StateDisplay/ErrorState';
+import Badge from '../../atoms/Badge';
+
+const ArticleWrapper = styled.article`
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 0;
+`;
+
+const ArticleHeader = styled.header`
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: center;
+`;
+
+const Title = styled.h1`
+  font-size: 2.75rem;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #111827;
+  margin-bottom: 1rem;
+`;
+
+const Meta = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+`;
+
+const Content = styled.div`
+  font-size: 1.125rem;
+  color: #374151;
+  line-height: 1.8;
+
+  h1, h2, h3 {
+    font-weight: 700;
+    margin-top: 2em;
+    margin-bottom: 1em;
+    line-height: 1.3;
+  }
+  p {
+    margin-bottom: 1.5em;
+  }
+  img {
+    max-width: 100%;
+    border-radius: 8px;
+    margin: 2em 0;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  }
+  a {
+    color: #4f46e5;
+    text-decoration: underline;
+  }
+`;
+
+const ArticleDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: article, loading, error } = useArticle(id);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="space-y-4">
+          <LoadingSkeleton className="h-12 w-3/4 mx-auto" />
+          <LoadingSkeleton className="h-6 w-1/2 mx-auto" />
+          <LoadingSkeleton className="h-96 w-full" />
+          <LoadingSkeleton className="h-6 w-full" />
+          <LoadingSkeleton className="h-6 w-5/6" />
+        </div>
+      );
+    }
+    if (error) return <ErrorState message={error.message} />;
+    if (!article) return <ErrorState message="기사를 찾을 수 없습니다." />;
+
+    return (
+      <ArticleWrapper>
+        <ArticleHeader>
+          <Title>{article.title}</Title>
+          <Meta>
+            <span>작성자: {article.author}</span>
+            <span>발행일: {new Date(article.publishDate).toLocaleDateString()}</span>
+          </Meta>
+        </ArticleHeader>
+
+        <Content dangerouslySetInnerHTML={{ __html: article.contentHTML }} />
+
+        {article.relatedCompanies && article.relatedCompanies.length > 0 && (
+          <div className="mt-12 pt-8 border-t">
+            <h3 className="text-xl font-bold mb-4">관련 기업</h3>
+            <div className="flex gap-2">
+              {article.relatedCompanies.map(companyId => (
+                // In a real app, you'd fetch company name for the badge
+                <Link key={companyId} to={`/companies/${companyId}`}>
+                  <Badge variant="primary">{companyId}</Badge>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+      </ArticleWrapper>
+    );
+  }
+
+  return (
+    <MainLayout>
+      {renderContent()}
+    </MainLayout>
+  );
+};
+
+export default ArticleDetailPage;

--- a/src/components/pages/ArticleListPage/index.tsx
+++ b/src/components/pages/ArticleListPage/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import MainLayout from '../../templates/MainLayout';
+import useArticles from '../../../hooks/useArticles';
+import ArticleCard from '../../molecules/ArticleCard';
+import Pagination from '../../molecules/Pagination';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import { ErrorState } from '../../molecules/StateDisplay/ErrorState';
+import { EmptyState } from '../../molecules/StateDisplay/EmptyState';
+
+const ArticleListPage: React.FC = () => {
+  const [filters, setFilters] = useState({
+    page: 1,
+    limit: 9,
+    tag: '',
+    sort: 'latest' as 'latest' | 'popularity',
+  });
+
+  const { data, loading, error } = useArticles(filters);
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFilters(prev => ({
+      ...prev,
+      page: 1,
+      [name]: value
+    }));
+  };
+
+  const handlePageChange = (page: number) => {
+    setFilters(prev => ({ ...prev, page }));
+  };
+
+  return (
+    <MainLayout>
+      <div className="mb-8 text-center">
+        <h1 className="text-4xl font-extrabold mb-2 tracking-tight">인터뷰 & 기획기사</h1>
+        <p className="text-lg text-gray-600">전북 바이오 기업들의 생생한 이야기를 만나보세요.</p>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow-sm mb-8 flex flex-wrap items-center gap-4 border border-gray-200">
+        <input
+          type="text"
+          name="tag"
+          placeholder="태그로 검색 (예: AI, 신약개발)"
+          value={filters.tag}
+          onChange={handleFilterChange}
+          className="p-2 border border-gray-300 rounded-md flex-grow focus:ring-2 focus:ring-indigo-500"
+        />
+        <select name="sort" value={filters.sort} onChange={handleFilterChange} className="p-2 border border-gray-300 rounded-md">
+          <option value="latest">최신순</option>
+          <option value="popularity">인기순</option>
+        </select>
+      </div>
+
+      {loading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(filters.limit)].map((_, i) => <LoadingSkeleton key={i} className="h-96" />)}
+        </div>
+      )}
+      {error && <ErrorState message={error.message} />}
+
+      {!loading && !error && (
+        <>
+          {data?.data.length === 0 ? (
+            <EmptyState message="조건에 맞는 기사가 없습니다." />
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {data?.data.map((article) => (
+                  <ArticleCard key={article.id} article={article} />
+                ))}
+              </div>
+              {data && data.pagination.totalPages > 1 && (
+                <Pagination
+                  currentPage={data.pagination.page}
+                  totalPages={data.pagination.totalPages}
+                  onPageChange={handlePageChange}
+                />
+              )}
+            </>
+          )}
+        </>
+      )}
+    </MainLayout>
+  );
+};
+
+export default ArticleListPage;

--- a/src/components/pages/CompaniesPage/index.tsx
+++ b/src/components/pages/CompaniesPage/index.tsx
@@ -1,13 +1,132 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import MainLayout from '../../templates/MainLayout';
+import useCompanies from '../../../hooks/useCompanies';
+import { Company, SizeCategory } from '../../../types/api';
+import CompanyCard from '../../molecules/CompanyCard';
+import TableList from '../../molecules/TableList';
+import Pagination from '../../molecules/Pagination';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import { ErrorState } from '../../molecules/StateDisplay/ErrorState';
+import { EmptyState } from '../../molecules/StateDisplay/EmptyState';
 
-const CompaniesPage = () => {
+const CompaniesPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [viewMode, setViewMode] = useState<'card' | 'table'>('card');
+
+  const [filters, setFilters] = useState({
+    page: 1,
+    limit: 12,
+    keyword: '',
+    region: '',
+    industry: '',
+    sizeCategory: '' as SizeCategory | '',
+    sort: 'latest',
+  });
+
+  const { data, loading, error } = useCompanies(filters);
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setFilters(prev => ({ ...prev, page: 1, [e.target.name]: e.target.value }));
+  };
+
+  const handlePageChange = (page: number) => {
+    setFilters(prev => ({ ...prev, page }));
+  };
+
+  const tableData = useMemo(() => {
+    const headers = ['기업명', '산업분야', '지역', '설립년도', '직원 수'];
+    const rows = data?.data.map((company: Company) => [
+      company.name,
+      company.industry,
+      company.region,
+      String(company.foundedYear),
+      String(company.employees),
+    ]) || [];
+    return { headers, rows };
+  }, [data]);
+
   return (
     <MainLayout>
-      <div style={{ padding: '2rem' }}>
-        <h1>JB 기업정보</h1>
-        <p>페이지가 준비중입니다.</p>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">기업 정보</h1>
+        <p className="text-gray-600">전북특별자치도의 유망한 바이오 기업들을 만나보세요.</p>
       </div>
+
+      <div className="bg-white p-4 rounded-lg shadow-sm mb-6 flex flex-wrap items-center gap-4 border border-gray-200">
+        <input
+          type="text"
+          name="keyword"
+          placeholder="기업명, 설명으로 검색..."
+          value={filters.keyword}
+          onChange={handleFilterChange}
+          className="p-2 border border-gray-300 rounded-md flex-grow focus:ring-2 focus:ring-indigo-500"
+        />
+        <select name="region" value={filters.region} onChange={handleFilterChange} className="p-2 border border-gray-300 rounded-md">
+          <option value="">전체 지역</option>
+          <option value="전주시">전주시</option>
+          <option value="군산시">군산시</option>
+          <option value="익산시">익산시</option>
+          <option value="김제시">김제시</option>
+        </select>
+        <select name="industry" value={filters.industry} onChange={handleFilterChange} className="p-2 border border-gray-300 rounded-md">
+          <option value="">전체 산업</option>
+          <option value="레드 바이오">레드 바이오</option>
+          <option value="그린 바이오">그린 바이오</option>
+          <option value="화이트 바이오">화이트 바이오</option>
+        </select>
+        <select name="sizeCategory" value={filters.sizeCategory} onChange={handleFilterChange} className="p-2 border border-gray-300 rounded-md">
+          <option value="">전체 규모</option>
+          <option value="Startup">스타트업</option>
+          <option value="SME">중견기업</option>
+          <option value="Large">대기업</option>
+        </select>
+      </div>
+
+      <div className="flex justify-end mb-4">
+        <div className="inline-flex rounded-md shadow-sm">
+          <button onClick={() => setViewMode('card')} className={`px-4 py-2 text-sm font-medium rounded-l-lg border ${viewMode === 'card' ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'}`}>
+            카드
+          </button>
+          <button onClick={() => setViewMode('table')} className={`px-4 py-2 text-sm font-medium rounded-r-lg border-t border-b border-r ${viewMode === 'table' ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'}`}>
+            테이블
+          </button>
+        </div>
+      </div>
+
+      {loading && <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"><LoadingSkeleton count={filters.limit} /></div>}
+      {error && <ErrorState message={error.message} />}
+
+      {!loading && !error && (
+        <>
+          {data?.data.length === 0 ? (
+            <EmptyState message="조건에 맞는 기업이 없습니다." />
+          ) : (
+            <>
+              {viewMode === 'card' ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {data?.data.map((company) => (
+                    <CompanyCard key={company.id} company={company} onClick={() => navigate(`/companies/${company.id}`)} />
+                  ))}
+                </div>
+              ) : (
+                <TableList
+                  headers={tableData.headers}
+                  rows={tableData.rows}
+                  onRowClick={(rowIndex) => navigate(`/companies/${data.data[rowIndex].id}`)}
+                />
+              )}
+              {data && data.pagination.totalPages > 1 && (
+                <Pagination
+                  currentPage={data.pagination.page}
+                  totalPages={data.pagination.totalPages}
+                  onPageChange={handlePageChange}
+                />
+              )}
+            </>
+          )}
+        </>
+      )}
     </MainLayout>
   );
 };

--- a/src/components/pages/CompanyDashboardPage/index.tsx
+++ b/src/components/pages/CompanyDashboardPage/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import useCompanyStats from '../../../hooks/useCompanyStats';
+import KPIGroup from '../../organisms/KPIGroup';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import { ErrorState } from '../../molecules/StateDisplay/ErrorState';
+import MainLayout from '../../templates/MainLayout';
+
+const CompanyDashboardPage: React.FC = () => {
+  const { data, loading, error } = useCompanyStats();
+
+  const kpis = data
+    ? [
+        { label: '총 등록 기업 수', value: data.totalCount },
+        { label: '스타트업', value: data.sizeDistribution.startup },
+        { label: '중견기업', value: data.sizeDistribution.sme },
+        { label: '대기업', value: data.sizeDistribution.large },
+      ]
+    : [];
+
+  return (
+    <MainLayout>
+      <h1 className="text-3xl font-bold mb-6">기업 정보 대시보드</h1>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-bold mb-4">핵심 지표</h2>
+        {loading && <LoadingSkeleton count={4} />}
+        {error && <ErrorState message={error.message} />}
+        {data && <KPIGroup kpis={kpis} />}
+      </section>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <section>
+          <h2 className="text-2xl font-bold mb-4">지역 기업정보</h2>
+          <div className="p-8 border rounded-lg bg-gray-50 text-center hover:shadow-lg transition-shadow">
+            <p className="mb-4 text-gray-600">지역별, 산업분야별 기업 정보를 찾아보세요.</p>
+            <Link to="/companies" className="font-bold text-indigo-600 hover:underline">
+              기업 목록 보러가기 &rarr;
+            </Link>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-2xl font-bold mb-4">인터뷰 & 기획기사</h2>
+          <div className="p-8 border rounded-lg bg-gray-50 text-center hover:shadow-lg transition-shadow">
+            <p className="mb-4 text-gray-600">전북 바이오 기업들의 생생한 이야기를 만나보세요.</p>
+            <Link to="/articles" className="font-bold text-indigo-600 hover:underline">
+              기사 목록 보러가기 &rarr;
+            </Link>
+          </div>
+        </section>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default CompanyDashboardPage;

--- a/src/components/pages/CompanyDetailPage/index.tsx
+++ b/src/components/pages/CompanyDetailPage/index.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import styled from 'styled-components';
+import useCompany from '../../../hooks/useCompany';
+import MainLayout from '../../templates/MainLayout';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import { ErrorState } from '../../molecules/StateDisplay/ErrorState';
+import Badge from '../../atoms/Badge';
+
+const DetailLayout = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  padding: 2rem 0;
+  @media (min-width: 1024px) {
+    grid-template-columns: 2fr 1fr;
+  }
+`;
+
+const MainContent = styled.main``;
+const Sidebar = styled.aside``;
+
+const CompanyHeader = styled.header`
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+`;
+
+const Logo = styled.img`
+  width: 100px;
+  height: 100px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  object-fit: cover;
+`;
+
+const TitleGroup = styled.div`
+  flex-grow: 1;
+`;
+
+const CompanyName = styled.h1`
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0;
+`;
+
+const Section = styled.section`
+  margin-bottom: 3rem;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #f3f4f6;
+`;
+
+const InfoCard = styled.div`
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  position: sticky;
+  top: 2rem;
+`;
+
+const InfoList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const InfoItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  font-size: 0.9rem;
+  &:not(:last-child) {
+    border-bottom: 1px solid #e5e7eb;
+  }
+`;
+
+const CompanyDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: company, loading, error } = useCompany(id);
+
+  if (loading) return <MainLayout><LoadingSkeleton count={8} /></MainLayout>;
+  if (error) return <MainLayout><ErrorState message={error.message} /></MainLayout>;
+  if (!company) return <MainLayout><ErrorState message="기업 정보를 찾을 수 없습니다." /></MainLayout>;
+
+  return (
+    <MainLayout>
+      <DetailLayout>
+        <MainContent>
+          <CompanyHeader>
+            <Logo src={company.logoUrl || `https://ui-avatars.com/api/?name=${company.name}&background=random`} alt={`${company.name} logo`} />
+            <TitleGroup>
+              <CompanyName>{company.name}</CompanyName>
+              <div className="flex gap-2 mt-2">
+                <Badge>{company.industry}</Badge>
+                <Badge variant="secondary">{company.region}</Badge>
+              </div>
+            </TitleGroup>
+          </CompanyHeader>
+
+          <Section>
+            <SectionTitle>기업 소개</SectionTitle>
+            <p className="text-gray-700 leading-relaxed">{company.description}</p>
+          </Section>
+
+          {company.products.length > 0 && (
+            <Section>
+              <SectionTitle>주요 제품</SectionTitle>
+              <ul className="list-disc list-inside space-y-2">
+                {company.products.map(p => <li key={p}>{p}</li>)}
+              </ul>
+            </Section>
+          )}
+
+          {company.achievements.length > 0 && (
+            <Section>
+              <SectionTitle>주요 활동</SectionTitle>
+              <ul className="list-disc list-inside space-y-2">
+                {company.achievements.map(a => <li key={a}>{a}</li>)}
+              </ul>
+            </Section>
+          )}
+
+          {company.patents.length > 0 && (
+            <Section>
+              <SectionTitle>보유 특허</SectionTitle>
+              <ul className="list-disc list-inside space-y-2">
+                {company.patents.map(p => <li key={p}>{p}</li>)}
+              </ul>
+            </Section>
+          )}
+        </MainContent>
+
+        <Sidebar>
+          <InfoCard>
+            <SectionTitle>기본 정보</SectionTitle>
+            <InfoList>
+              <InfoItem><span>설립년도</span> <strong>{company.foundedYear}</strong></InfoItem>
+              <InfoItem><span>기업규모</span> <strong>{company.sizeCategory}</strong></InfoItem>
+              <InfoItem><span>직원 수</span> <strong>{company.employees}명</strong></InfoItem>
+            </InfoList>
+
+            <SectionTitle className="mt-6">담당자 정보</SectionTitle>
+            <InfoList>
+              <InfoItem><span>이름</span> <strong>{company.contact.name}</strong></InfoItem>
+              <InfoItem><span>이메일</span> <a href={`mailto:${company.contact.email}`} className="text-indigo-600 hover:underline">{company.contact.email}</a></InfoItem>
+              <InfoItem><span>연락처</span> <strong>{company.contact.phone}</strong></InfoItem>
+            </InfoList>
+
+            {company.websiteUrl && (
+              <a href={company.websiteUrl} target="_blank" rel="noopener noreferrer" className="block w-full text-center bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg mt-6 hover:bg-indigo-700">
+                웹사이트 방문
+              </a>
+            )}
+          </InfoCard>
+        </Sidebar>
+      </DetailLayout>
+    </MainLayout>
+  );
+};
+
+export default CompanyDetailPage;

--- a/src/hooks/useArticle.ts
+++ b/src/hooks/useArticle.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { Article } from '../types/api';
+
+const useArticle = (id: string | null) => {
+  const [data, setData] = useState<Article | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setLoading(false);
+      setData(null);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/articles/${id}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: Article = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  return { data, loading, error };
+};
+
+export default useArticle;

--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import { Article, PaginatedResponse } from '../types/api';
+
+// --- TYPE DEFINITIONS ---
+
+interface ArticlesFilters {
+  page?: number;
+  limit?: number;
+  tag?: string;
+  publishDate?: string; // YYYY-MM
+  sort?: 'latest' | 'popularity';
+}
+
+// --- HOOK ---
+
+const useArticles = (filters: ArticlesFilters) => {
+  const [data, setData] = useState<PaginatedResponse<Article> | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const filtersJson = JSON.stringify(filters);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams();
+        Object.entries(JSON.parse(filtersJson)).forEach(([key, value]) => {
+          if (value !== undefined && value !== null && value !== '') {
+            params.append(key, String(value));
+          }
+        });
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/articles?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: PaginatedResponse<Article> = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [filtersJson]);
+
+  return { data, loading, error };
+};
+
+export default useArticles;

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -1,0 +1,108 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Company, Article } from '../types/api';
+
+// This is a mock token for development.
+// In a real app, this would come from an auth context or store.
+const MOCK_AUTH_TOKEN = 'fake-jwt-token-for-user-1';
+
+const useBookmarks = () => {
+  const [bookmarkedCompanies, setBookmarkedCompanies] = useState<Company[]>([]);
+  const [bookmarkedArticles, setBookmarkedArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+  const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+  const bookmarksUrl = `${apiUrl}${apiPrefix}/users/me/bookmarks`;
+
+  const getHeaders = () => ({
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${MOCK_AUTH_TOKEN}`,
+  });
+
+  const fetchBookmarks = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const [companiesRes, articlesRes] = await Promise.all([
+        fetch(`${bookmarksUrl}/companies`, { headers: getHeaders() }),
+        fetch(`${bookmarksUrl}/articles`, { headers: getHeaders() }),
+      ]);
+
+      if (!companiesRes.ok || !articlesRes.ok) {
+        throw new Error('Failed to fetch bookmarks');
+      }
+
+      const companies = await companiesRes.json();
+      const articles = await articlesRes.json();
+
+      setBookmarkedCompanies(companies);
+      setBookmarkedArticles(articles);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [bookmarksUrl]);
+
+  useEffect(() => {
+    fetchBookmarks();
+  }, [fetchBookmarks]);
+
+  const addCompanyBookmark = async (companyId: string) => {
+    await fetch(`${bookmarksUrl}/companies`, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify({ companyId }),
+    });
+    await fetchBookmarks();
+  };
+
+  const removeCompanyBookmark = async (companyId: string) => {
+    await fetch(`${bookmarksUrl}/companies/${companyId}`, {
+      method: 'DELETE',
+      headers: getHeaders(),
+    });
+    await fetchBookmarks();
+  };
+
+  const addArticleBookmark = async (articleId: string) => {
+    await fetch(`${bookmarksUrl}/articles`, {
+        method: 'POST',
+        headers: getHeaders(),
+        body: JSON.stringify({ articleId }),
+    });
+    await fetchBookmarks();
+  };
+
+  const removeArticleBookmark = async (articleId: string) => {
+    await fetch(`${bookmarksUrl}/articles/${articleId}`, {
+        method: 'DELETE',
+        headers: getHeaders(),
+    });
+    await fetchBookmarks();
+  };
+
+  const isCompanyBookmarked = (companyId: string) =>
+    bookmarkedCompanies.some(c => c.id === companyId);
+
+  const isArticleBookmarked = (articleId: string) =>
+    bookmarkedArticles.some(a => a.id === articleId);
+
+  return {
+    bookmarkedCompanies,
+    bookmarkedArticles,
+    addCompanyBookmark,
+    removeCompanyBookmark,
+    addArticleBookmark,
+    removeArticleBookmark,
+    isCompanyBookmarked,
+    isArticleBookmarked,
+    loading,
+    error,
+    refetch: fetchBookmarks,
+  };
+};
+
+export default useBookmarks;

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react';
+import { Company, PaginatedResponse, SizeCategory } from '../types/api';
+
+// --- TYPE DEFINITIONS ---
+
+interface CompaniesFilters {
+  page?: number;
+  limit?: number;
+  region?: string;
+  industry?: string;
+  sizeCategory?: SizeCategory;
+  hasInvestment?: boolean;
+  sort?: 'latest' | 'name' | 'investmentSize';
+  keyword?: string;
+}
+
+// --- HOOK ---
+
+const useCompanies = (filters: CompaniesFilters) => {
+  const [data, setData] = useState<PaginatedResponse<Company> | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // A more stable dependency for useEffect
+  const filtersJson = JSON.stringify(filters);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams();
+        Object.entries(filters).forEach(([key, value]) => {
+          if (value !== undefined && value !== null && value !== '') {
+            params.append(key, String(value));
+          }
+        });
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/companies?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: PaginatedResponse<Company> = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [filtersJson]); // Re-fetch only when filters actually change
+
+  return { data, loading, error };
+};
+
+export default useCompanies;

--- a/src/hooks/useCompany.ts
+++ b/src/hooks/useCompany.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { Company } from '../types/api';
+
+const useCompany = (id: string | null) => {
+  const [data, setData] = useState<Company | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setLoading(false);
+      setData(null);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/companies/${id}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: Company = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  return { data, loading, error };
+};
+
+export default useCompany;

--- a/src/hooks/useCompanyStats.ts
+++ b/src/hooks/useCompanyStats.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { CompanyStats } from '../types/api';
+
+const useCompanyStats = () => {
+  const [data, setData] = useState<CompanyStats | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/companies/stats`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: CompanyStats = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []); // Fetch only once on component mount
+
+  return { data, loading, error };
+};
+
+export default useCompanyStats;

--- a/src/hooks/useCompareCompanies.ts
+++ b/src/hooks/useCompareCompanies.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { Company } from '../types/api';
+
+const useCompareCompanies = (ids: string[]) => {
+  const [data, setData] = useState<Company[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const idsJson = JSON.stringify(ids);
+
+  useEffect(() => {
+    // Convert back to array for the check
+    const idArray = JSON.parse(idsJson);
+    if (!idArray || idArray.length === 0) {
+      setLoading(false);
+      setData([]);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams();
+        params.append('ids', idArray.join(','));
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/companies/compare?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: Company[] = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [idsJson]);
+
+  return { data, loading, error };
+};
+
+export default useCompareCompanies;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -51,3 +51,66 @@ export interface Event {
 }
 
 export type ContentItem = News | Event;
+
+// ===== Types for Company & Article Features =====
+
+export interface CompanyContact {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export type SizeCategory = "Startup" | "SME" | "Large";
+
+export interface Company {
+  id: string;
+  name: string;
+  logoUrl?: string;
+  industry: string;
+  region: string;
+  foundedYear: number;
+  sizeCategory: SizeCategory;
+  employees: number;
+  description: string;
+  products: string[];
+  achievements: string[];
+  patents: string[];
+  contact: CompanyContact;
+  websiteUrl?: string;
+  relatedArticles: string[];
+}
+
+export interface Article {
+  id: string;
+  title: string;
+  author: string;
+  publishDate: string; // ISO 8601 date string
+  tags: string[];
+  contentHTML: string;
+  images: string[];
+  relatedCompanies: string[];
+}
+
+export interface CompanyStats {
+  totalCount: number;
+  regionDistribution: Record<string, number>;
+  sizeDistribution: {
+    startup: number;
+    sme: number;
+    large: number;
+  };
+}
+
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: Pagination;
+}


### PR DESCRIPTION
This commit introduces the new company information and article sections.

- Updates the OpenAPI specification with new endpoints for companies and articles.
- Implements the backend API, including data models, routers, and mock data.
- Adds a suite of frontend hooks for fetching data from the new endpoints.
- Creates new pages for the company dashboard, company list, company detail, article list, and article detail.
- Adds new reusable components for displaying company and article data.