### PR TITLE
feat: Implement Support Program detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import CompanyDashboardPage from './components/pages/CompanyDashboardPage';
 import CompanyDetailPage from './components/pages/CompanyDetailPage';
 import ArticleListPage from './components/pages/ArticleListPage';
 import ArticleDetailPage from './components/pages/ArticleDetailPage';
+import SupportProgramDetailPage from './components/pages/SupportProgramDetailPage';
 
 function App() {
   return (
@@ -51,7 +52,7 @@ function App() {
       <Route path="/cluster/policy" element={<ClusterPolicyPage />} />
       <Route path="/cluster/policy/:policyId" element={<PolicyDetailPage />} />
       <Route path="/announcements" element={<AnnouncementsPage />} />
-      <Route path="/support/:category/:announcementId" element={<AnnouncementDetailPage />} />
+      <Route path="/support-programs/:id" element={<SupportProgramDetailPage />} />
 
       {/* Incubation Routes */}
       <Route path="/incubation" element={<IncubationPage />} />

--- a/src/components/pages/SupportProgramDetailPage/index.tsx
+++ b/src/components/pages/SupportProgramDetailPage/index.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import useSupportProgram from '../../../hooks/useSupportProgram';
+import MainLayout from '../../templates/MainLayout';
+import { LoadingSkeleton } from '../../molecules/StateDisplay/LoadingSkeleton';
+import ErrorState from '../../molecules/StateDisplay/ErrorState';
+import Badge from '../../atoms/Badge';
+
+const PageWrapper = styled.div`
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+`;
+
+const Header = styled.header`
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #e5e7eb;
+`;
+
+const Title = styled.h1`
+  font-size: 2.25rem;
+  font-weight: 800;
+  line-height: 1.3;
+  margin-bottom: 1rem;
+`;
+
+const MetaInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #6b7280;
+`;
+
+const ContentBody = styled.div`
+  line-height: 1.8;
+  font-size: 1.1rem;
+`;
+
+const InfoTable = styled.div`
+  margin-top: 3rem;
+  background-color: #f9fafb;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  overflow: hidden;
+`;
+
+const InfoRow = styled.div`
+  display: flex;
+  padding: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const InfoLabel = styled.div`
+  font-weight: 600;
+  width: 120px;
+  flex-shrink: 0;
+`;
+
+const InfoValue = styled.div`
+  flex-grow: 1;
+`;
+
+const SupportProgramDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: program, loading, error } = useSupportProgram(id || null);
+
+  if (loading) return <MainLayout><PageWrapper><LoadingSkeleton count={10} /></PageWrapper></MainLayout>;
+  if (error) return <MainLayout><PageWrapper><ErrorState message={error.message} /></PageWrapper></MainLayout>;
+  if (!program) return <MainLayout><PageWrapper><ErrorState message="지원 프로그램을 찾을 수 없습니다." /></PageWrapper></MainLayout>;
+
+  return (
+    <MainLayout>
+      <PageWrapper>
+        <Header>
+          <Title>{program.title}</Title>
+          <MetaInfo>
+            <span>주관: {program.organization}</span>
+            <Badge $variant={program.status === 'ONGOING' ? 'success' : 'secondary'}>{program.status}</Badge>
+          </MetaInfo>
+        </Header>
+
+        <ContentBody>
+          <p>{program.description}</p>
+        </ContentBody>
+
+        <InfoTable>
+          <InfoRow>
+            <InfoLabel>지원 분야</InfoLabel>
+            <InfoValue>{program.category}</InfoValue>
+          </InfoRow>
+          <InfoRow>
+            <InfoLabel>신청 기간</InfoLabel>
+            <InfoValue>{program.startDate} ~ {program.endDate}</InfoValue>
+          </InfoRow>
+          <InfoRow>
+            <InfoLabel>지원 대상</InfoLabel>
+            <InfoValue>{program.targetCompany}</InfoValue>
+          </InfoRow>
+          <InfoRow>
+            <InfoLabel>지원 유형</InfoLabel>
+            <InfoValue>
+              <div className="flex gap-2">
+                {program.supportType.map(type => <Badge key={type}>{type}</Badge>)}
+              </div>
+            </InfoValue>
+          </InfoRow>
+        </InfoTable>
+
+        <div className="mt-12 text-center">
+            <a href={program.externalUrl} target="_blank" rel="noopener noreferrer" className="inline-block bg-indigo-600 text-white font-bold py-3 px-8 rounded-lg hover:bg-indigo-700 transition-colors">
+                공고 원문 보러가기
+            </a>
+        </div>
+      </PageWrapper>
+    </MainLayout>
+  );
+};
+
+export default SupportProgramDetailPage;

--- a/src/hooks/useSupportProgram.ts
+++ b/src/hooks/useSupportProgram.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { SupportProgram } from '../types/api';
+
+const useSupportProgram = (id: string | null) => {
+  const [data, setData] = useState<SupportProgram | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setLoading(false);
+      setData(null);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+        const apiPrefix = process.env.REACT_APP_API_PREFIX || '/api';
+        const response = await fetch(`${apiUrl}${apiPrefix}/support-programs/${id}`);
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const result: SupportProgram = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  return { data, loading, error };
+};
+
+export default useSupportProgram;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -270,6 +270,16 @@ const incubationCentersHandler = http.get('/api/incubation-centers', ({ request 
   return HttpResponse.json(data);
 });
 
+const supportProgramDetailHandler = http.get('/api/support-programs/:id', ({ params }) => {
+  const { id } = params;
+  const program = supportProgramsDb.find(p => p.id === id);
+  if (program) {
+    return HttpResponse.json(program);
+  } else {
+    return new HttpResponse(null, { status: 404 });
+  }
+});
+
 export const handlers = [
   dashboardHandler,
   organizationsHandler,
@@ -279,4 +289,5 @@ export const handlers = [
   supportProgramsHandler,
   technologiesHandler,
   incubationCentersHandler,
+  supportProgramDetailHandler,
 ];

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -114,3 +114,20 @@ export interface PaginatedResponse<T> {
   data: T[];
   pagination: Pagination;
 }
+
+export type SupportProgramStatus = "ONGOING" | "UPCOMING" | "CLOSED";
+
+export interface SupportProgram {
+  id: string;
+  title: string;
+  organization: string;
+  description: string;
+  startDate: string; // ISO Date
+  endDate: string; // ISO Date
+  status: SupportProgramStatus;
+  category: string;
+  supportType: string[];
+  targetCompany: string;
+  externalUrl: string;
+  createdAt: string; // ISO DateTime
+}


### PR DESCRIPTION
This commit adds the missing detail page for Support Programs to resolve a runtime error when navigating to `/support-programs/:id`.

- Adds a new `SupportProgramDetailPage` component.
- Adds a new `useSupportProgram` hook to fetch data for a single program.
- Adds the route `/support-programs/:id` to `App.tsx`.
- Adds a corresponding MSW handler to mock the detail API endpoint.