### PR TITLE
fix(backend): add all missing mock data and fix 404 error

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -160,7 +160,7 @@ stats_db: List[Stat] = [
 
 support_programs_db: List[SupportProgram] = [
     SupportProgram(
-        id="sp-001",
+        id="sp_001",
         title="2024년 바이오 스타트업 인큐베이팅 프로그램",
         organization="J-Bio-Hub",
         description="초기 바이오 스타트업을 위한 사무공간, 멘토링, 시드 투자 지원.",
@@ -174,7 +174,7 @@ support_programs_db: List[SupportProgram] = [
         createdAt=datetime(2024, 7, 15, 10, 0, 0)
     ),
     SupportProgram(
-        id="sp-002",
+        id="sp_002",
         title="글로벌 진출 지원사업",
         organization="전북테크노파크",
         description="해외 전시회 참가, 바이어 매칭, 수출 컨설팅 지원.",
@@ -280,7 +280,7 @@ registration_requests_db: List[RegistrationRequest] = [
 applications_db: List[Application] = [
     Application(
         id="app-001",
-        programId="sp-001",
+        programId="sp_001",
         programTitle="2024년 바이오 스타트업 인큐베이팅 프로그램",
         status=ApplicationStatus.PENDING,
         appliedAt=datetime(2024, 7, 22, 15, 0, 0),


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of errors that occurred during application startup and API requests. The root cause was a severely incomplete mock data file (`backend/db/mock_data.py`).

This commit resolves the following issues:
1.  A series of `ImportError` exceptions for various `_db` variables (`announcements_db`, `infra_db`, `users_db`, etc.).
2.  A `404 Not Found` error for `GET /api/support-programs/sp_001` due to an ID mismatch.

The following changes were made:
- Populated `backend/db/mock_data.py` with mock data for all required database tables.
- Corrected the ID format in `support_programs_db` to use underscores instead of hyphens.
- Added empty `__init__.py` files to the `backend/db` and `backend/routers` directories to ensure they are treated as Python packages.