### PR TITLE
feat(tech): implement filter and detail page for patents

### DIFF
--- a/src/components/molecules/FilterBar/index.tsx
+++ b/src/components/molecules/FilterBar/index.tsx
@@ -46,12 +46,25 @@ export interface Filter {
   options: FilterOption[];
 }
 
+const FilterPlaceholder = styled.div`
+  font-size: 0.875rem;
+  color: #6b7280;
+`;
+
 interface FilterBarProps {
-  filters: Filter[];
-  onFilterChange: (filterName: string, value: string) => void;
+  filters?: Filter[];
+  onFilterChange?: (filterName: string, value: string) => void;
 }
 
 const FilterBar: React.FC<FilterBarProps> = ({ filters, onFilterChange }) => {
+  if (!filters || filters.length === 0 || !onFilterChange) {
+    return (
+      <FilterBarWrapper>
+        <FilterPlaceholder>Filter controls will be displayed here.</FilterPlaceholder>
+      </FilterBarWrapper>
+    );
+  }
+
   return (
     <FilterBarWrapper>
       {filters.map((filter) => (


### PR DESCRIPTION
This commit implements a new feature for the technology/patents section of the application and fixes a subsequent build error.

The following features have been added:
1.  **Filtering on the Patent List Page (`/tech/patents`):**
    - A new reusable `FilterBar` component has been implemented. Its props are optional to prevent breaking other pages.
    - Users can now filter the list of technologies by "Category" and "Date Range".
    - The backend API has been updated to support date-range filtering.

2.  **Clickable Patent Items and Detail Page:**
    - Items in the patent list are now clickable.
    - Clicking an item navigates to a new detail page (`/tech-summary/detail/:id`).
    - The detail page fetches live data for the specific patent from the backend.

This commit also includes a comprehensive update to `backend/db/mock_data.py` to populate all missing mock data, resolving a series of `ImportError` exceptions.