### PR TITLE
feat(tech): implement filter and detail page for patents

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "author": "Jeonbuk Bio Team",
   "license": "MIT",
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@types/styled-components": "^5.1.34",
     "react": "^18.2.0",


### PR DESCRIPTION
This commit implements a new feature for the technology/patents section of the application and includes several fixes for related bugs and environment setup issues.

Feature:
- Implemented filtering on the Patent List Page (`/tech/patents`) by "Category" and "Date Range".
- Made patent list items clickable, navigating to a new detail page.
- The detail page now fetches live data from the backend API.

Fixes:
- Added a proxy to `package.json` to resolve API request failures during local development.
- Made the `FilterBar` component's props optional to prevent build errors on other pages.
- Populated `backend/db/mock_data.py` with all missing mock data to resolve a series of `ImportError` exceptions.
- Added `__init__.py` files to backend directories to ensure correct package handling.