### PR TITLE
fix(tech): correct ID mismatch for technology detail page

### DIFF
--- a/backend/db/mock_data.py
+++ b/backend/db/mock_data.py
@@ -234,7 +234,7 @@ mentors_db: List[Mentor] = [
 
 technologies_db: List[Technology] = [
     Technology(
-        id="tech-001",
+        id="tech_001",
         title="AI 기반 신약 후보물질 발굴 플랫폼",
         summary="딥러닝을 활용하여 신약 개발 기간과 비용을 획기적으로 단축시키는 플랫폼 기술",
         organization="전북대학교 AI 연구센터",


### PR DESCRIPTION
This commit fixes a 404 Not Found error on the technology detail page. The error was caused by an inconsistency between the ID format used in the frontend request (`tech_001`) and the mock data (`tech-001`).

The ID in `backend/db/mock_data.py` for the `technologies_db` has been updated to use an underscore, which resolves the 404 error.